### PR TITLE
Fix encoding/decoding for deposit transactions

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -268,7 +268,7 @@ impl Transaction {
                 if with_header {
                     Header {
                         list: false,
-                        payload_length: 1 + length_of_length(payload_length) + payload_length,
+                        payload_length: 1 + 1 + length_of_length(payload_length) + payload_length,
                     }
                     .encode(out);
                 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -262,6 +262,23 @@ impl Transaction {
                 self.encode_fields(out);
                 signature.encode_with_eip155_chain_id(out, *chain_id);
             }
+            #[cfg(feature = "optimism")]
+            Transaction::Deposit(_) => {
+                let payload_length = self.fields_len() + signature.payload_len();
+                if with_header {
+                    Header {
+                        list: false,
+                        payload_length: 1 + length_of_length(payload_length) + payload_length,
+                    }
+                    .encode(out);
+                }
+                out.put_u8(self.tx_type() as u8);
+                out.put_u8(DEPOSIT_VERSION);
+                let header = Header { list: true, payload_length };
+                header.encode(out);
+                self.encode_fields(out);
+                signature.encode(out);
+            }
             _ => {
                 let payload_length = self.fields_len() + signature.payload_len();
                 if with_header {
@@ -365,6 +382,11 @@ impl Compact for Transaction {
             2 => {
                 let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
                 (Transaction::Eip1559(tx), buf)
+            }
+            #[cfg(feature = "optimism")]
+            126 => {
+                let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
+                (Transaction::Deposit(tx), buf)
             }
             _ => unreachable!("Junk data in database: unknown Transaction variant"),
         }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1013,20 +1013,29 @@ impl Compact for TransactionSignedNoHash {
         // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
         buf.put_u8(0);
 
-        let sig_bit = self.signature.to_compact(buf) as u8;
         let zstd_bit = self.transaction.input().len() >= 32;
 
-        let tx_bits = if zstd_bit {
+        let mut tmp = bytes::BytesMut::with_capacity(200);
+        let mut tx_bits = self.transaction.to_compact(&mut tmp) as u8;
+
+        if tx_bits > 2 {
+            // If the transaction type exceeds the initially allocated 2 bits, we need to
+            // write a sentinel 3 to denote that the actual value is held in the next byte
+            // of the buffer.
+            buf.put_u8(tx_bits);
+            tx_bits = 3
+        };
+
+        let sig_bit = self.signature.to_compact(buf) as u8;
+
+        if zstd_bit {
             TRANSACTION_COMPRESSOR.with(|compressor| {
                 let mut compressor = compressor.borrow_mut();
-                let mut tmp = bytes::BytesMut::with_capacity(200);
-                let tx_bits = self.transaction.to_compact(&mut tmp);
 
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
-                tx_bits as u8
             })
         } else {
-            self.transaction.to_compact(buf) as u8
+            buf.put_slice(&tmp);
         };
 
         // Replace bitflags with the actual values
@@ -1040,9 +1049,18 @@ impl Compact for TransactionSignedNoHash {
         let bitflags = buf.get_u8() as usize;
 
         let sig_bit = bitflags & 1;
+        let zstd_bit = bitflags >> 3;
+
+        let transaction_type_bits = (bitflags & 0b110) >> 1;
+        let transaction_type = if transaction_type_bits == 3 {
+            // A bitmask of 3 means that the actual value is held in the next byte of the buffer.
+            buf.get_u8() as usize
+        } else {
+            transaction_type_bits
+        };
+
         let (signature, buf) = Signature::from_compact(buf, sig_bit);
 
-        let zstd_bit = bitflags >> 3;
         let (transaction, buf) = if zstd_bit != 0 {
             TRANSACTION_DECOMPRESSOR.with(|decompressor| {
                 let mut decompressor = decompressor.borrow_mut();
@@ -1062,13 +1080,11 @@ impl Compact for TransactionSignedNoHash {
 
                 // TODO: enforce that zstd is only present at a "top" level type
 
-                let transaction_type = (bitflags & 0b110) >> 1;
                 let (transaction, _) = Transaction::from_compact(tmp.as_slice(), transaction_type);
 
                 (transaction, buf)
             })
         } else {
-            let transaction_type = bitflags >> 1;
             Transaction::from_compact(buf, transaction_type)
         };
 

--- a/crates/storage/codecs/derive/src/arbitrary.rs
+++ b/crates/storage/codecs/derive/src/arbitrary.rs
@@ -26,7 +26,7 @@ pub fn maybe_generate_tests(args: TokenStream, ast: &DeriveInput) -> TokenStream
                     let mut buf = vec![];
                     let len = field.clone().to_compact(&mut buf);
                     let (decoded, _) = super::#type_ident::from_compact(&buf, len);
-                    assert!(field == decoded);
+                    assert_eq!(field, decoded);
                 }
             });
         } else if arg.to_string() == "rlp" {


### PR DESCRIPTION
* Fixes `encode_with_signature` and `Transaction.from_compact` for Optimism deposit transactions. This addresses some failing transaction primitives proptests.
* Adds variable-length encoding support for transaction types with values greater than or equal to 3.
  * In the case of tx types >= 3, we write a `3` in the 2-bit tx_type field and then write the entire type value in the next byte of data.

Notably, the type is defined to use at most 7 bits of data per EIP-2718, and we will still have 4 unused bits in the prior metadata byte. The resulting 1 or 2-byte metadata header looks like:
  ```
0000 | isCompressed | txType(0-1) | signatureParity
0 | txType  # if txType >= 3, else byte omitted
```

We could choose to pack the remaining tx type bits in the single metadata header, but we only have 4 remaining free bits and would need to overflow into the next byte regardless. This approach is likely preferable to the packed alternative, which may look like:
```
txType(2-6) | isCompressed | txType(0-1) | signatureParity
0000000 | txType(7)  # if txType >=3, else byte omitted
```

~Open question:
Given that deposit transactions have no signature, is it more correct to support `encode_with_signature` for this transaction type or is it better for this method to explicitly no-op or raise an assertion failure? This question further extends to `TransactionSignedNoHash.to_compact/from_compact`, which at present only allocate 2 bits to serialize the transaction type. Supporting the 126-valued deposit type would require either a full 7 bits for the transaction type or some amount of aliasing (3 is currently unused and fits in 2 bits but may one day be added to the core Ethereum protocol)~

Relates to #11 