### PR TITLE
Add variable-length compact support for TxType and Transaction

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1022,29 +1022,20 @@ impl Compact for TransactionSignedNoHash {
         // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
         buf.put_u8(0);
 
+        let sig_bit = self.signature.to_compact(buf) as u8;
         let zstd_bit = self.transaction.input().len() >= 32;
 
-        let mut tmp = bytes::BytesMut::with_capacity(200);
-        let mut tx_bits = self.transaction.to_compact(&mut tmp) as u8;
-
-        if tx_bits > 2 {
-            // If the transaction type exceeds the initially allocated 2 bits, we need to
-            // write a sentinel 3 to denote that the actual value is held in the next byte
-            // of the buffer.
-            buf.put_u8(tx_bits);
-            tx_bits = 3
-        };
-
-        let sig_bit = self.signature.to_compact(buf) as u8;
-
-        if zstd_bit {
+        let tx_bits = if zstd_bit {
             TRANSACTION_COMPRESSOR.with(|compressor| {
                 let mut compressor = compressor.borrow_mut();
+                let mut tmp = bytes::BytesMut::with_capacity(200);
+                let tx_bits = self.transaction.to_compact(&mut tmp);
 
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
+                tx_bits as u8
             })
         } else {
-            buf.put_slice(&tmp);
+            self.transaction.to_compact(buf) as u8
         };
 
         // Replace bitflags with the actual values
@@ -1058,18 +1049,9 @@ impl Compact for TransactionSignedNoHash {
         let bitflags = buf.get_u8() as usize;
 
         let sig_bit = bitflags & 1;
-        let zstd_bit = bitflags >> 3;
-
-        let transaction_type_bits = (bitflags & 0b110) >> 1;
-        let transaction_type = if transaction_type_bits == 3 {
-            // A bitmask of 3 means that the actual value is held in the next byte of the buffer.
-            buf.get_u8() as usize
-        } else {
-            transaction_type_bits
-        };
-
         let (signature, buf) = Signature::from_compact(buf, sig_bit);
 
+        let zstd_bit = bitflags >> 3;
         let (transaction, buf) = if zstd_bit != 0 {
             TRANSACTION_DECOMPRESSOR.with(|decompressor| {
                 let mut decompressor = decompressor.borrow_mut();
@@ -1089,11 +1071,13 @@ impl Compact for TransactionSignedNoHash {
 
                 // TODO: enforce that zstd is only present at a "top" level type
 
+                let transaction_type = (bitflags & 0b110) >> 1;
                 let (transaction, _) = Transaction::from_compact(tmp.as_slice(), transaction_type);
 
                 (transaction, buf)
             })
         } else {
+            let transaction_type = bitflags >> 1;
             Transaction::from_compact(buf, transaction_type)
         };
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -268,7 +268,7 @@ impl Transaction {
                 if with_header {
                     Header {
                         list: false,
-                        payload_length: 1 + length_of_length(payload_length) + payload_length,
+                        payload_length: 1 + 1 + length_of_length(payload_length) + payload_length,
                     }
                     .encode(out);
                 }
@@ -344,32 +344,35 @@ impl Transaction {
 }
 
 impl Compact for Transaction {
+    // Serializes the TxType to the buffer if necessary, returning 2 bits of the type as an
+    // identifier instead of the length.
     fn to_compact<B>(self, buf: &mut B) -> usize
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
+        let identifier = self.tx_type().to_compact(buf);
         match self {
             Transaction::Legacy(tx) => {
                 tx.to_compact(buf);
-                0
             }
             Transaction::Eip2930(tx) => {
                 tx.to_compact(buf);
-                1
             }
             Transaction::Eip1559(tx) => {
                 tx.to_compact(buf);
-                2
             }
             #[cfg(feature = "optimism")]
             Transaction::Deposit(tx) => {
                 tx.to_compact(buf);
-                126
             }
         }
+        identifier
     }
 
-    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+    // For backwards compatibility purposes, only 2 bits of the type are encoded in the identifier
+    // parameter. In the case of a 3, the full transaction type is read from the buffer as a
+    // single byte.
+    fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         match identifier {
             0 => {
                 let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
@@ -383,10 +386,16 @@ impl Compact for Transaction {
                 let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
                 (Transaction::Eip1559(tx), buf)
             }
-            #[cfg(feature = "optimism")]
-            126 => {
-                let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
-                (Transaction::Deposit(tx), buf)
+            3 => {
+                let identifier = buf.get_u8() as usize;
+                match identifier {
+                    #[cfg(feature = "optimism")]
+                    126 => {
+                        let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
+                        (Transaction::Deposit(tx), buf)
+                    }
+                    _ => unreachable!("Junk data in database: unknown Transaction variant"),
+                }
             }
             _ => unreachable!("Junk data in database: unknown Transaction variant"),
         }


### PR DESCRIPTION
Proposed as an alternative to #16, adding the variable-length encoding directly in the `to_compact` and `from_compact` implementations for `TxType` and `Transaction`.

For the purposes of backwards-compatibility, this continues to reserve 2 bits to encode the transaction type data in the serialized entity's `StructFlags`. Whenever the value is greater than or equal to 3, we use 3 as the 2-bit identifier and encode the full type value to the buffer as a single byte.

This has the somewhat-counterintuitive behavior of conditionally splitting the data across the (repurposed) "length" value as well as the buffer, while the type easily fits within the `usize` return value on all architectures.

Note that with this change, a compact-serialized Transaction will have a 1 or 2-byte metadata header with the following format:
```
0000 | isCompressed | txType(0-1) | signatureParity
0 | txType  # if txType >= 3, else byte omitted
```