### PR TITLE
[trivial] Fix dev chainspec when optimism feature enabled

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -169,6 +169,8 @@ pub static DEV: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Shanghai, ForkCondition::Timestamp(0)),
         ]),
+        #[cfg(feature = "optimism")]
+        optimism: None,
     }
     .into()
 });


### PR DESCRIPTION
Add missing `optimism` config to the `DEV` chainspec