### PR TITLE
op-reth: Fix reth-primitives signature tests

### DIFF
--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -157,6 +157,7 @@ mod tests {
 
     #[test]
     fn test_payload_len_with_eip155_chain_id() {
+        // Select 1 as an arbitrary nonzero value for R and S, as v() always returns 0 for (0, 0).
         let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
 
         assert_eq!(3, signature.payload_len_with_eip155_chain_id(None));
@@ -164,8 +165,19 @@ mod tests {
         assert_eq!(4, signature.payload_len_with_eip155_chain_id(Some(47)));
     }
 
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_zero_signature_payload_len_with_eip155_chain_id() {
+        let zero_signature = Signature { r: U256::ZERO, s: U256::ZERO, odd_y_parity: false };
+
+        assert_eq!(3, zero_signature.payload_len_with_eip155_chain_id(None));
+        assert_eq!(3, zero_signature.payload_len_with_eip155_chain_id(Some(1)));
+        assert_eq!(3, zero_signature.payload_len_with_eip155_chain_id(Some(47)));
+    }
+
     #[test]
     fn test_v() {
+        // Select 1 as an arbitrary nonzero value for R and S, as v() always returns 0 for (0, 0).
         let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
         assert_eq!(27, signature.v(None));
         assert_eq!(37, signature.v(Some(1)));
@@ -179,14 +191,15 @@ mod tests {
     #[test]
     fn test_zero_signature_v() {
         let signature = Signature { r: U256::ZERO, s: U256::ZERO, odd_y_parity: false };
-        assert_eq!(0, signature.v(None));
 
-        let signature = Signature { r: U256::ZERO, s: U256::ZERO, odd_y_parity: false };
+        assert_eq!(0, signature.v(None));
         assert_eq!(0, signature.v(Some(1)));
+        assert_eq!(0, signature.v(Some(47)));
     }
 
     #[test]
     fn test_encode_and_decode_with_eip155_chain_id() {
+        // Select 1 as an arbitrary nonzero value for R and S, as v() always returns 0 for (0, 0).
         let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
 
         let mut encoded = BytesMut::new();

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_payload_len_with_eip155_chain_id() {
-        let signature = Signature { r: U256::default(), s: U256::default(), odd_y_parity: false };
+        let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
 
         assert_eq!(3, signature.payload_len_with_eip155_chain_id(None));
         assert_eq!(3, signature.payload_len_with_eip155_chain_id(Some(1)));
@@ -166,18 +166,28 @@ mod tests {
 
     #[test]
     fn test_v() {
-        let signature = Signature { r: U256::default(), s: U256::default(), odd_y_parity: false };
+        let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
         assert_eq!(27, signature.v(None));
         assert_eq!(37, signature.v(Some(1)));
 
-        let signature = Signature { r: U256::default(), s: U256::default(), odd_y_parity: true };
+        let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: true };
         assert_eq!(28, signature.v(None));
         assert_eq!(38, signature.v(Some(1)));
     }
 
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_zero_signature_v() {
+        let signature = Signature { r: U256::ZERO, s: U256::ZERO, odd_y_parity: false };
+        assert_eq!(0, signature.v(None));
+
+        let signature = Signature { r: U256::ZERO, s: U256::ZERO, odd_y_parity: false };
+        assert_eq!(0, signature.v(Some(1)));
+    }
+
     #[test]
     fn test_encode_and_decode_with_eip155_chain_id() {
-        let signature = Signature { r: U256::default(), s: U256::default(), odd_y_parity: false };
+        let signature = Signature { r: U256::from(1), s: U256::from(1), odd_y_parity: false };
 
         let mut encoded = BytesMut::new();
         signature.encode_with_eip155_chain_id(&mut encoded, None);


### PR DESCRIPTION
Updates signature tests in `reth-primitives` to be compatible with the special-case optimism serialization for zero signatures (`R: 0, S: 0, V: 0`).

Adds optimism-only test cases for this zero signature behavior

Fixes the following tests:
```
reth-primitives transaction::signature::tests::test_encode_and_decode_with_eip155_chain_id
reth-primitives transaction::signature::tests::test_payload_len_with_eip155_chain_id
reth-primitives transaction::signature::tests::test_v
```