### PR TITLE
add op-node specific command line flags

### DIFF
--- a/bin/reth/src/args/mod.rs
+++ b/bin/reth/src/args/mod.rs
@@ -39,4 +39,10 @@ pub use txpool_args::TxPoolArgs;
 mod dev_args;
 pub use dev_args::DevArgs;
 
+/// RollupArgs for configuring the op-reth rollup
+#[cfg(feature = "optimism")]
+mod rollup_args;
+#[cfg(feature = "optimism")]
+pub use rollup_args::RollupArgs;
+
 pub mod utils;

--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -5,7 +5,7 @@
 #[command(next_help_heading = "Rollup")]
 pub struct RollupArgs {
     /// HTTP endpoint for the sequencer mempool
-    #[arg(long = "rollup.sequencerhttp", value_name = "HTTP_URL")]
+    #[arg(long = "rollup.sequencer-http", value_name = "HTTP_URL")]
     pub sequencer_http: Option<String>,
 
     /// Disable transaction pool gossip

--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -1,0 +1,14 @@
+//! clap [Args](clap::Args) for op-reth rollup configuration
+
+/// Parameters for rollup configuration
+#[derive(Debug, clap::Args)]
+#[command(next_help_heading = "Rollup")]
+pub struct RollupArgs {
+    /// HTTP endpoint for the sequencer mempool
+    #[arg(long = "rollup.sequencerhttp", value_name = "HTTP_URL")]
+    pub sequencer_http: Option<String>,
+
+    /// Disable transaction pool gossip
+    #[arg(long = "rollup.disabletxpoolgossip")]
+    pub disable_txpool_gossip: bool,
+}

--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -9,6 +9,6 @@ pub struct RollupArgs {
     pub sequencer_http: Option<String>,
 
     /// Disable transaction pool gossip
-    #[arg(long = "rollup.disabletxpoolgossip")]
+    #[arg(long = "rollup.disable-tx-pool-gossip")]
     pub disable_txpool_gossip: bool,
 }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -150,6 +150,10 @@ pub struct Command {
 
     #[clap(flatten)]
     dev: DevArgs,
+
+    #[cfg(feature = "optimism")]
+    #[clap(flatten)]
+    rollup: crate::args::RollupArgs,
 }
 
 impl Command {


### PR DESCRIPTION
Adds --rollup.sequencerhttp and --rollup.disabletxpoolgossip flags to op-reth node (without implementations) per issue https://github.com/paradigmxyz/reth/issues/3794