### PR TITLE
feat(node): Add Compute Pending Block Rollup CLI Option

### DIFF
--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -11,4 +11,11 @@ pub struct RollupArgs {
     /// Disable transaction pool gossip
     #[arg(long = "rollup.disable-tx-pool-gossip")]
     pub disable_txpool_gossip: bool,
+
+    /// By default the pending block equals the latest block
+    /// to save resources and not leak txs from the tx-pool,
+    /// this flag enables computing of the pending block
+    /// from the tx-pool instead.
+    #[arg(long = "rollup.compute-pending-block"))]
+    pub compute_pending_block: bool,
 }

--- a/bin/reth/src/args/rollup_args.rs
+++ b/bin/reth/src/args/rollup_args.rs
@@ -16,6 +16,6 @@ pub struct RollupArgs {
     /// to save resources and not leak txs from the tx-pool,
     /// this flag enables computing of the pending block
     /// from the tx-pool instead.
-    #[arg(long = "rollup.compute-pending-block"))]
+    #[arg(long = "rollup.compute-pending-block")]
     pub compute_pending_block: bool,
 }


### PR DESCRIPTION
**Description**


This PR adds a `rollup.compute-pending-block` flag to the node cli as a rollup arg.

By default, the pending block is computed using the latest block to preserve tx pool privacy.
This flag allows the node operator to compute the pending block using the tx pool.

**Testing**

No testing required to keep the diff minimal and consistent with op-geth.

**Metadata**

Addresses part of #4004.
