### PR TITLE
op-reth: Fix serialization/deserialization for Deposit Receipts

### DIFF
--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -64,7 +64,7 @@ proptest-derive = "0.3"
 default = ["serde"]
 serde = ["dep:serde", "smol_str/serde"]
 arbitrary = ["reth-primitives/arbitrary", "dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
-optimism = []
+optimism = ["reth-primitives/optimism"]
 
 [[test]]
 name = "fuzz_roundtrip"


### PR DESCRIPTION
* Encode/decode optional `Receipt.deposit_nonce` field for `Deposit` transaction receipts
  * Increases the length of the RLP list by 1 element when a deposit nonce is present.
* Ensure that the appropriate RLP length is written for all non-legacy transaction receipts, including Deposits
* Add custom implementation of `arbitrary` and `arbitrary_with` for the `Receipt` type, ensuring that `Receipt.deposit_nonce` is only `Some` whenever the transaction type is `TxType::DEPOSIT`

Open questions:
* Is there a simpler way to define this arbitrary/arbitrary_with strategy leveraging the existing `main_codec` macro?

Fixes the following tests:
```
reth-eth-wire types::receipts::ReceiptsTests::proptest
```