### PR TITLE
Revert "use the parameters from the optimism config in 1559 base fee computation"

### DIFF
--- a/bin/reth/src/args/rpc_server_args.rs
+++ b/bin/reth/src/args/rpc_server_args.rs
@@ -346,7 +346,6 @@ impl RpcServerArgs {
     ) -> Result<AuthServerHandle, RpcError>
     where
         Provider: BlockReaderIdExt
-            + ChainSpecProvider
             + HeaderProvider
             + StateProviderFactory
             + EvmEnvProvider

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -246,18 +246,10 @@ impl StorageInner {
 
     /// Fills in pre-execution header fields based on the current best block and given
     /// transactions.
-    pub(crate) fn build_header_template(
-        &self,
-        transactions: &Vec<TransactionSigned>,
-        chain_spec: Arc<ChainSpec>,
-    ) -> Header {
+    pub(crate) fn build_header_template(&self, transactions: &Vec<TransactionSigned>) -> Header {
         // check previous block for base fee
-        let base_fee_per_gas = self.headers.get(&self.best_block).and_then(|parent| {
-            parent.next_block_base_fee(
-                chain_spec.elasticity_multiplier(),
-                chain_spec.base_fee_change_denominator(),
-            )
-        });
+        let base_fee_per_gas =
+            self.headers.get(&self.best_block).and_then(|parent| parent.next_block_base_fee());
 
         let mut header = Header {
             parent_hash: self.best_hash,
@@ -343,9 +335,8 @@ impl StorageInner {
         &mut self,
         transactions: Vec<TransactionSigned>,
         executor: &mut Executor<DB>,
-        chain_spec: Arc<ChainSpec>,
     ) -> Result<(SealedHeader, PostState), BlockExecutionError> {
-        let header = self.build_header_template(&transactions, chain_spec);
+        let header = self.build_header_template(&transactions);
 
         let block = Block { header, body: transactions, ommers: vec![], withdrawals: None };
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -109,7 +109,6 @@ where
                 let to_engine = this.to_engine.clone();
                 let client = this.client.clone();
                 let chain_spec = Arc::clone(&this.chain_spec);
-                let chain_spec2 = Arc::clone(&this.chain_spec);
                 let pool = this.pool.clone();
                 let events = this.pipe_line_events.take();
                 let canon_state_notification = this.canon_state_notification.clone();
@@ -132,11 +131,7 @@ where
                     let substate = SubState::new(State::new(client.latest().unwrap()));
                     let mut executor = Executor::new(chain_spec, substate);
 
-                    match storage.build_and_execute(
-                        transactions.clone(),
-                        &mut executor,
-                        chain_spec2,
-                    ) {
+                    match storage.build_and_execute(transactions.clone(), &mut executor) {
                         Ok((new_header, post_state)) => {
                             // clear all transactions from pool
                             pool.remove_transactions(transactions.iter().map(|tx| tx.hash()));

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -294,12 +294,7 @@ pub fn validate_header_regarding_parent(
                 constants::EIP1559_INITIAL_BASE_FEE
             } else {
                 // This BaseFeeMissing will not happen as previous blocks are checked to have them.
-                parent
-                    .next_block_base_fee(
-                        chain_spec.base_fee_change_denominator(),
-                        chain_spec.elasticity_multiplier(),
-                    )
-                    .ok_or(ConsensusError::BaseFeeMissing)?
+                parent.next_block_base_fee().ok_or(ConsensusError::BaseFeeMissing)?
             };
         if expected_base_fee != base_fee {
             return Err(ConsensusError::BaseFeeDiff { expected: expected_base_fee, got: base_fee })

--- a/crates/payload/builder/src/payload.rs
+++ b/crates/payload/builder/src/payload.rs
@@ -134,14 +134,7 @@ impl PayloadBuilderAttributes {
             prevrandao: Some(self.prev_randao),
             gas_limit: U256::from(parent.gas_limit),
             // calculate basefee based on parent block's gas usage
-            basefee: U256::from(
-                parent
-                    .next_block_base_fee(
-                        chain_spec.base_fee_change_denominator(),
-                        chain_spec.elasticity_multiplier(),
-                    )
-                    .unwrap_or_default(),
-            ),
+            basefee: U256::from(parent.next_block_base_fee().unwrap_or_default()),
         };
 
         (cfg, block_env)

--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -1,14 +1,10 @@
 //! Helpers for working with EIP-1559 base fee
 
+use crate::constants;
+
 /// Calculate base fee for next block. [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) spec
-pub fn calculate_next_block_base_fee(
-    gas_used: u64,
-    gas_limit: u64,
-    base_fee: u64,
-    elasticity: u64,
-    change_denominator: u64,
-) -> u64 {
-    let gas_target = gas_limit / elasticity;
+pub fn calculate_next_block_base_fee(gas_used: u64, gas_limit: u64, base_fee: u64) -> u64 {
+    let gas_target = gas_limit / constants::EIP1559_ELASTICITY_MULTIPLIER;
 
     if gas_used == gas_target {
         return base_fee
@@ -19,14 +15,14 @@ pub fn calculate_next_block_base_fee(
             1,
             base_fee as u128 * gas_used_delta as u128 /
                 gas_target as u128 /
-                change_denominator as u128,
+                constants::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR as u128,
         );
         base_fee + (base_fee_delta as u64)
     } else {
         let gas_used_delta = gas_target - gas_used;
         let base_fee_per_gas_delta = base_fee as u128 * gas_used_delta as u128 /
             gas_target as u128 /
-            change_denominator as u128;
+            constants::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR as u128;
 
         base_fee.saturating_sub(base_fee_per_gas_delta as u64)
     }
@@ -58,13 +54,7 @@ mod tests {
         for i in 0..base_fee.len() {
             assert_eq!(
                 next_base_fee[i],
-                calculate_next_block_base_fee(
-                    gas_used[i],
-                    gas_limit[i],
-                    base_fee[i],
-                    crate::constants::EIP1559_ELASTICITY_MULTIPLIER,
-                    crate::constants::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR,
-                )
+                calculate_next_block_base_fee(gas_used[i], gas_limit[i], base_fee[i])
             );
         }
     }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -201,10 +201,7 @@ pub static OP_GOERLI: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             ),
             (Hardfork::Regolith, ForkCondition::Timestamp(1679079600)),
         ]),
-        optimism: Some(OptimismConfig {
-            eip_1559_elasticity: crate::constants::EIP1559_DEFAULT_OPTIMISM_ELASTICITY_MULTIPLIER,
-            eip_1559_denominator: crate::constants::EIP1559_DEFAULT_OPTIMISM_CHANGE_DENOMINATOR,
-        }),
+        optimism: Some(OptimismConfig { eip_1559_elasticity: 10, eip_1559_denominator: 50 }),
     }
     .into()
 });
@@ -421,30 +418,6 @@ impl ChainSpec {
         }
 
         ForkId { hash: forkhash, next: 0 }
-    }
-
-    /// Return the configured EIP-1559 max base fee change denominator
-    pub fn base_fee_change_denominator(&self) -> u64 {
-        #[cfg(not(feature = "optimism"))]
-        {
-            crate::constants::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR
-        }
-        #[cfg(feature = "optimism")]
-        {
-            self.optimism.as_ref().unwrap().eip_1559_denominator
-        }
-    }
-
-    /// Return the configured EIP-1559 elasticity multiplier
-    pub fn elasticity_multiplier(&self) -> u64 {
-        #[cfg(not(feature = "optimism"))]
-        {
-            crate::constants::EIP1559_ELASTICITY_MULTIPLIER
-        }
-        #[cfg(feature = "optimism")]
-        {
-            self.optimism.as_ref().unwrap().eip_1559_elasticity
-        }
     }
 
     /// Build a chainspec using [`ChainSpecBuilder`]

--- a/crates/primitives/src/constants/mod.rs
+++ b/crates/primitives/src/constants/mod.rs
@@ -37,15 +37,11 @@ pub const BEACON_NONCE: u64 = 0u64;
 /// See <https://github.com/paradigmxyz/reth/issues/3233>.
 pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 30_000_000;
 
-/// The minimum tx fee below which the txpool will reject the transaction.
+/// The minimal value the basefee can decrease to.
 ///
-/// Configured to `7` WEI which is the lowest possible value of base fee under mainnet EIP-1559
-/// parameters. `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559>
-/// is `8`, or 12.5%. Once the base fee has dropped to `7` WEI it cannot decrease further because
-/// 12.5% of 7 is less than 1.
-///
-/// Note that min base fee under different 1559 parameterizations (e.g. Optimism's) may differ,
-/// but there's no signifant harm in leaving this setting as is.
+/// The `BASE_FEE_MAX_CHANGE_DENOMINATOR` <https://eips.ethereum.org/EIPS/eip-1559> is `8`, or 12.5%.
+/// Once the base fee has dropped to `7` WEI it cannot decrease further because 12.5% of 7 is less
+/// than 1.
 pub const MIN_PROTOCOL_BASE_FEE: u64 = 7;
 
 /// Same as [MIN_PROTOCOL_BASE_FEE] but as a U256.
@@ -54,19 +50,21 @@ pub const MIN_PROTOCOL_BASE_FEE_U256: U256 = U256::from_limbs([7u64, 0, 0, 0]);
 /// Initial base fee as defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
 pub const EIP1559_INITIAL_BASE_FEE: u64 = 1_000_000_000;
 
-/// Elasticity multiplier as defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
-pub const EIP1559_ELASTICITY_MULTIPLIER: u64 = 2;
-
 /// Base fee max change denominator as defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
+#[cfg(not(feature = "optimism"))]
 pub const EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR: u64 = 8;
+
+/// Elasticity multiplier as defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
+#[cfg(not(feature = "optimism"))]
+pub const EIP1559_ELASTICITY_MULTIPLIER: u64 = 2;
 
 /// Base fee max change denominator for Optimism.
 #[cfg(feature = "optimism")]
-pub const EIP1559_DEFAULT_OPTIMISM_CHANGE_DENOMINATOR: u64 = 50;
+pub const EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR: u64 = 50;
 
 /// Elasticity multiplier for Optimism.
 #[cfg(feature = "optimism")]
-pub const EIP1559_DEFAULT_OPTIMISM_ELASTICITY_MULTIPLIER: u64 = 6;
+pub const EIP1559_ELASTICITY_MULTIPLIER: u64 = 10;
 
 /// Multiplier for converting gwei to wei.
 pub const GWEI_TO_WEI: u64 = 1_000_000_000;

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -166,14 +166,8 @@ impl Header {
     /// Calculate base fee for next block according to the EIP-1559 spec.
     ///
     /// Returns a `None` if no base fee is set, no EIP-1559 support
-    pub fn next_block_base_fee(&self, elasticity: u64, change_denominator: u64) -> Option<u64> {
-        Some(calculate_next_block_base_fee(
-            self.gas_used,
-            self.gas_limit,
-            self.base_fee_per_gas?,
-            elasticity,
-            change_denominator,
-        ))
+    pub fn next_block_base_fee(&self) -> Option<u64> {
+        Some(calculate_next_block_base_fee(self.gas_used, self.gas_limit, self.base_fee_per_gas?))
     }
 
     /// Seal the header with a known hash.

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -12,8 +12,7 @@ use jsonrpsee::{
 };
 use reth_network_api::{NetworkInfo, Peers};
 use reth_provider::{
-    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt,
-    StateProviderFactory,
+    BlockReaderIdExt, EvmEnvProvider, HeaderProvider, ReceiptProviderIdExt, StateProviderFactory,
 };
 use reth_rpc::{
     eth::{cache::EthStateCache, gas_oracle::GasPriceOracle},
@@ -41,11 +40,10 @@ pub async fn launch<Provider, Pool, Network, Tasks, EngineApi>(
 ) -> Result<AuthServerHandle, RpcError>
 where
     Provider: BlockReaderIdExt
-        + ChainSpecProvider
-        + EvmEnvProvider
-        + HeaderProvider
         + ReceiptProviderIdExt
+        + HeaderProvider
         + StateProviderFactory
+        + EvmEnvProvider
         + Clone
         + Unpin
         + 'static,
@@ -87,7 +85,6 @@ pub async fn launch_with_eth_api<Provider, Pool, Network, EngineApi>(
 ) -> Result<AuthServerHandle, RpcError>
 where
     Provider: BlockReaderIdExt
-        + ChainSpecProvider
         + HeaderProvider
         + StateProviderFactory
         + EvmEnvProvider

--- a/crates/rpc/rpc/src/eth/api/block.rs
+++ b/crates/rpc/rpc/src/eth/api/block.rs
@@ -9,14 +9,13 @@ use crate::{
 };
 use reth_network_api::NetworkInfo;
 use reth_primitives::{BlockId, BlockNumberOrTag, TransactionMeta};
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::{Block, Index, RichBlock, TransactionReceipt};
 use reth_transaction_pool::TransactionPool;
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {

--- a/crates/rpc/rpc/src/eth/api/call.rs
+++ b/crates/rpc/rpc/src/eth/api/call.rs
@@ -14,9 +14,7 @@ use crate::{
 use ethers_core::utils::get_contract_address;
 use reth_network_api::NetworkInfo;
 use reth_primitives::{AccessList, BlockId, BlockNumberOrTag, Bytes, U256};
-use reth_provider::{
-    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProvider, StateProviderFactory,
-};
+use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProvider, StateProviderFactory};
 use reth_revm::{
     access_list::AccessListInspector,
     database::{State, SubState},
@@ -36,8 +34,7 @@ const MIN_CREATE_GAS: u64 = 53_000u64;
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
     Pool: TransactionPool + Clone + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {
     /// Estimate gas needed for execution of the `request` at the [BlockId].

--- a/crates/rpc/rpc/src/eth/api/fees.rs
+++ b/crates/rpc/rpc/src/eth/api/fees.rs
@@ -8,7 +8,7 @@ use reth_network_api::NetworkInfo;
 use reth_primitives::{
     basefee::calculate_next_block_base_fee, BlockNumberOrTag, SealedHeader, U256,
 };
-use reth_provider::{BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderFactory};
+use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderFactory};
 use reth_rpc_types::{FeeHistory, TxGasAndReward};
 use reth_transaction_pool::TransactionPool;
 use tracing::debug;
@@ -16,8 +16,7 @@ use tracing::debug;
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
     Pool: TransactionPool + Clone + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {
     /// Returns a suggestion for a gas price for legacy transactions.
@@ -120,8 +119,6 @@ where
             last_header.gas_used,
             last_header.gas_limit,
             last_header.base_fee_per_gas.unwrap_or_default(),
-            self.provider().chain_spec().elasticity_multiplier(),
-            self.provider().chain_spec().base_fee_change_denominator(),
         )));
 
         Ok(FeeHistory {

--- a/crates/rpc/rpc/src/eth/api/mod.rs
+++ b/crates/rpc/rpc/src/eth/api/mod.rs
@@ -16,9 +16,7 @@ use reth_network_api::NetworkInfo;
 use reth_primitives::{
     Address, BlockId, BlockNumberOrTag, ChainInfo, SealedBlock, H256, U256, U64,
 };
-use reth_provider::{
-    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderBox, StateProviderFactory,
-};
+use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderBox, StateProviderFactory};
 use reth_rpc_types::{SyncInfo, SyncStatus};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use reth_transaction_pool::TransactionPool;
@@ -80,7 +78,7 @@ pub struct EthApi<Provider, Pool, Network> {
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider: BlockReaderIdExt + ChainSpecProvider,
+    Provider: BlockReaderIdExt,
 {
     /// Creates a new, shareable instance using the default tokio task spawner.
     pub fn new(
@@ -190,8 +188,7 @@ where
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
 {
     /// Returns the state at the given [BlockId] enum.
     pub fn state_at_block_id(&self, at: BlockId) -> EthResult<StateProviderBox<'_>> {
@@ -225,8 +222,7 @@ where
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {
@@ -247,10 +243,7 @@ where
             // assumed child block is in the next slot
             latest.timestamp += 12;
             // base fee of the child block
-            latest.base_fee_per_gas = latest.next_block_base_fee(
-                self.provider().chain_spec().elasticity_multiplier(),
-                self.provider().chain_spec().base_fee_change_denominator(),
-            );
+            latest.base_fee_per_gas = latest.next_block_base_fee();
 
             PendingBlockEnvOrigin::DerivedFromLatest(latest)
         };
@@ -328,8 +321,7 @@ impl<Provider, Pool, Events> Clone for EthApi<Provider, Pool, Events> {
 impl<Provider, Pool, Network> EthApiSpec for EthApi<Provider, Pool, Network>
 where
     Pool: TransactionPool + Clone + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + 'static,
 {
     /// Returns the current ethereum protocol version.

--- a/crates/rpc/rpc/src/eth/api/server.rs
+++ b/crates/rpc/rpc/src/eth/api/server.rs
@@ -16,8 +16,8 @@ use reth_primitives::{
     AccessListWithGasUsed, Address, BlockId, BlockNumberOrTag, Bytes, H256, H64, U256, U64,
 };
 use reth_provider::{
-    BlockIdReader, BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider,
-    HeaderProvider, StateProviderFactory,
+    BlockIdReader, BlockReader, BlockReaderIdExt, EvmEnvProvider, HeaderProvider,
+    StateProviderFactory,
 };
 use reth_rpc_api::EthApiServer;
 use reth_rpc_types::{
@@ -36,7 +36,6 @@ where
     Provider: BlockReader
         + BlockIdReader
         + BlockReaderIdExt
-        + ChainSpecProvider
         + HeaderProvider
         + StateProviderFactory
         + EvmEnvProvider
@@ -399,12 +398,12 @@ mod tests {
     use reth_interfaces::test_utils::{generators, generators::Rng};
     use reth_network_api::noop::NoopNetwork;
     use reth_primitives::{
-        constants::{self, ETHEREUM_BLOCK_GAS_LIMIT},
-        Block, BlockNumberOrTag, Header, TransactionSigned, H256, U256,
+        basefee::calculate_next_block_base_fee, constants::ETHEREUM_BLOCK_GAS_LIMIT, Block,
+        BlockNumberOrTag, Header, TransactionSigned, H256, U256,
     };
     use reth_provider::{
-        test_utils::NoopProvider, BlockReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider,
-        StateProviderFactory,
+        test_utils::{MockEthProvider, NoopProvider},
+        BlockReader, BlockReaderIdExt, EvmEnvProvider, StateProviderFactory,
     };
     use reth_rpc_api::EthApiServer;
     use reth_rpc_types::FeeHistory;
@@ -413,7 +412,6 @@ mod tests {
     fn build_test_eth_api<
         P: BlockReaderIdExt
             + BlockReader
-            + ChainSpecProvider
             + EvmEnvProvider
             + StateProviderFactory
             + Unpin
@@ -451,10 +449,6 @@ mod tests {
     /// Handler for: `eth_test_fee_history`
     // TODO: Split this into multiple tests, and add tests for percentiles.
     #[tokio::test]
-    // TODO(op-reth): fix this for optimism. currently the MockEthProvider uses
-    // a chain_spec for mainnet, but this test needs the Optimism config values
-    // to be specified.
-    #[cfg(not(feature = "optimism"))]
     async fn test_fee_history() {
         let mut rng = generators::rng();
 
@@ -466,7 +460,7 @@ mod tests {
         let mut gas_used_ratios = Vec::new();
         let mut base_fees_per_gas = Vec::new();
         let mut last_header = None;
-        let mock_provider = reth_provider::test_utils::MockEthProvider::default();
+        let mock_provider = MockEthProvider::default();
 
         for i in (0..block_count).rev() {
             let hash = H256::random();
@@ -527,15 +521,11 @@ mod tests {
 
         // Add final base fee (for the next block outside of the request)
         let last_header = last_header.unwrap();
-        base_fees_per_gas.push(U256::from(
-            reth_primitives::basefee::calculate_next_block_base_fee(
-                last_header.gas_used,
-                last_header.gas_limit,
-                last_header.base_fee_per_gas.unwrap_or_default(),
-                constants::EIP1559_ELASTICITY_MULTIPLIER,
-                constants::EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR,
-            ),
-        ));
+        base_fees_per_gas.push(U256::from(calculate_next_block_base_fee(
+            last_header.gas_used,
+            last_header.gas_limit,
+            last_header.base_fee_per_gas.unwrap_or_default(),
+        )));
 
         let eth_api = build_test_eth_api(mock_provider);
 

--- a/crates/rpc/rpc/src/eth/api/state.rs
+++ b/crates/rpc/rpc/src/eth/api/state.rs
@@ -9,16 +9,14 @@ use reth_primitives::{
     U256,
 };
 use reth_provider::{
-    AccountReader, BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProvider,
-    StateProviderFactory,
+    AccountReader, BlockReaderIdExt, EvmEnvProvider, StateProvider, StateProviderFactory,
 };
 use reth_rpc_types::{EIP1186AccountProofResponse, StorageProof};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Pool: TransactionPool + Clone + 'static,
     Network: Send + Sync + 'static,
 {

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -19,9 +19,7 @@ use reth_primitives::{
     TransactionKind::{Call, Create},
     TransactionMeta, TransactionSigned, TransactionSignedEcRecovered, H256, U128, U256, U64,
 };
-use reth_provider::{
-    BlockReaderIdExt, ChainSpecProvider, EvmEnvProvider, StateProviderBox, StateProviderFactory,
-};
+use reth_provider::{BlockReaderIdExt, EvmEnvProvider, StateProviderBox, StateProviderFactory};
 use reth_revm::{
     database::{State, SubState},
     env::{fill_block_env_with_coinbase, tx_env_with_recovered},
@@ -228,8 +226,7 @@ pub trait EthTransactions: Send + Sync {
 impl<Provider, Pool, Network> EthTransactions for EthApi<Provider, Pool, Network>
 where
     Pool: TransactionPool + Clone + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {
     fn call_gas_limit(&self) -> u64 {
@@ -641,8 +638,7 @@ where
 
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: 'static,
 {
     /// Helper function for `eth_getTransactionReceipt`
@@ -666,8 +662,7 @@ where
 impl<Provider, Pool, Network> EthApi<Provider, Pool, Network>
 where
     Pool: TransactionPool + 'static,
-    Provider:
-        BlockReaderIdExt + ChainSpecProvider + StateProviderFactory + EvmEnvProvider + 'static,
+    Provider: BlockReaderIdExt + StateProviderFactory + EvmEnvProvider + 'static,
     Network: NetworkInfo + Send + Sync + 'static,
 {
     pub(crate) fn sign_request(

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1,18 +1,18 @@
 use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
-    ChainSpecProvider, EvmEnvProvider, HeaderProvider, PostState, PostStateDataProvider,
-    ReceiptProviderIdExt, StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider,
-    TransactionsProvider, WithdrawalsProvider,
+    EvmEnvProvider, HeaderProvider, PostState, PostStateDataProvider, ReceiptProviderIdExt,
+    StateProvider, StateProviderBox, StateProviderFactory, StateRootProvider, TransactionsProvider,
+    WithdrawalsProvider,
 };
 use parking_lot::Mutex;
 use reth_db::models::StoredBlockBodyIndices;
 use reth_interfaces::{provider::ProviderError, Result};
 use reth_primitives::{
     keccak256, Account, Address, Block, BlockHash, BlockHashOrNumber, BlockId, BlockNumber,
-    BlockWithSenders, Bytecode, Bytes, ChainInfo, ChainSpec, Header, Receipt, SealedBlock,
-    SealedHeader, StorageKey, StorageValue, TransactionMeta, TransactionSigned,
-    TransactionSignedNoHash, TxHash, TxNumber, H256, U256,
+    BlockWithSenders, Bytecode, Bytes, ChainInfo, Header, Receipt, SealedBlock, SealedHeader,
+    StorageKey, StorageValue, TransactionMeta, TransactionSigned, TransactionSignedNoHash, TxHash,
+    TxNumber, H256, U256,
 };
 use reth_revm_primitives::primitives::{BlockEnv, CfgEnv};
 use std::{
@@ -22,7 +22,7 @@ use std::{
 };
 
 /// A mock implementation for Provider interfaces.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct MockEthProvider {
     /// Local block store
     pub blocks: Arc<Mutex<HashMap<H256, Block>>>,
@@ -30,19 +30,6 @@ pub struct MockEthProvider {
     pub headers: Arc<Mutex<HashMap<H256, Header>>>,
     /// Local account store
     pub accounts: Arc<Mutex<HashMap<Address, ExtendedAccount>>>,
-    /// Local chain spec
-    pub chain_spec: Arc<ChainSpec>,
-}
-
-impl Default for MockEthProvider {
-    fn default() -> MockEthProvider {
-        MockEthProvider {
-            blocks: Default::default(),
-            headers: Default::default(),
-            accounts: Default::default(),
-            chain_spec: Arc::new(reth_primitives::ChainSpecBuilder::mainnet().build()),
-        }
-    }
 }
 
 /// An extended account for local store
@@ -170,12 +157,6 @@ impl HeaderProvider for MockEthProvider {
 
     fn sealed_header(&self, number: BlockNumber) -> Result<Option<SealedHeader>> {
         Ok(self.header_by_number(number)?.map(|h| h.seal_slow()))
-    }
-}
-
-impl ChainSpecProvider for MockEthProvider {
-    fn chain_spec(&self) -> Arc<ChainSpec> {
-        self.chain_spec.clone()
     }
 }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -93,10 +93,10 @@
 //!
 //! ```
 //! use reth_primitives::MAINNET;
-//! use reth_provider::{ChainSpecProvider, StateProviderFactory};
+//! use reth_provider::StateProviderFactory;
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::{EthTransactionValidator, Pool, TransactionPool};
-//!  async fn t<C>(client: C)  where C: StateProviderFactory + ChainSpecProvider + Clone + 'static{
+//!  async fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static{
 //!     let pool = Pool::eth_pool(
 //!         EthTransactionValidator::new(client, MAINNET.clone(), TokioTaskExecutor::default()),
 //!         Default::default(),
@@ -118,12 +118,12 @@
 //! ```
 //! use futures_util::Stream;
 //! use reth_primitives::MAINNET;
-//! use reth_provider::{BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, StateProviderFactory};
+//! use reth_provider::{BlockReaderIdExt, CanonStateNotification, StateProviderFactory};
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::{EthTransactionValidator, Pool};
 //! use reth_transaction_pool::maintain::maintain_transaction_pool_future;
 //!  async fn t<C, St>(client: C, stream: St)
-//!    where C: StateProviderFactory + BlockReaderIdExt + ChainSpecProvider + Clone + 'static,
+//!    where C: StateProviderFactory + BlockReaderIdExt + Clone + 'static,
 //!     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
 //!     {
 //!     let pool = Pool::eth_pool(

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -10,9 +10,7 @@ use futures_util::{
     FutureExt, Stream, StreamExt,
 };
 use reth_primitives::{Address, BlockHash, BlockNumberOrTag, FromRecoveredTransaction};
-use reth_provider::{
-    BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, PostState, StateProviderFactory,
-};
+use reth_provider::{BlockReaderIdExt, CanonStateNotification, PostState, StateProviderFactory};
 use reth_tasks::TaskSpawner;
 use std::{
     borrow::Borrow,
@@ -51,7 +49,7 @@ pub fn maintain_transaction_pool_future<Client, P, St, Tasks>(
     config: MaintainPoolConfig,
 ) -> BoxFuture<'static, ()>
 where
-    Client: StateProviderFactory + BlockReaderIdExt + ChainSpecProvider + Clone + Send + 'static,
+    Client: StateProviderFactory + BlockReaderIdExt + Clone + Send + 'static,
     P: TransactionPoolExt + 'static,
     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
     Tasks: TaskSpawner + 'static,
@@ -72,7 +70,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
     task_spawner: Tasks,
     config: MaintainPoolConfig,
 ) where
-    Client: StateProviderFactory + ChainSpecProvider + BlockReaderIdExt + Clone + Send + 'static,
+    Client: StateProviderFactory + BlockReaderIdExt + Clone + Send + 'static,
     P: TransactionPoolExt + 'static,
     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
     Tasks: TaskSpawner + 'static,
@@ -85,12 +83,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
         let info = BlockInfo {
             last_seen_block_hash: latest.hash,
             last_seen_block_number: latest.number,
-            pending_basefee: latest
-                .next_block_base_fee(
-                    client.chain_spec().elasticity_multiplier(),
-                    client.chain_spec().base_fee_change_denominator(),
-                )
-                .unwrap_or_default(),
+            pending_basefee: latest.next_block_base_fee().unwrap_or_default(),
         };
         pool.set_block_info(info);
     }
@@ -212,12 +205,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 }
 
                 // base fee for the next block: `new_tip+1`
-                let pending_block_base_fee = new_tip
-                    .next_block_base_fee(
-                        client.chain_spec().elasticity_multiplier(),
-                        client.chain_spec().base_fee_change_denominator(),
-                    )
-                    .unwrap_or_default();
+                let pending_block_base_fee = new_tip.next_block_base_fee().unwrap_or_default();
 
                 // we know all changed account in the new chain
                 let new_changed_accounts: HashSet<_> =
@@ -293,12 +281,7 @@ pub async fn maintain_transaction_pool<Client, P, St, Tasks>(
                 let tip = blocks.tip();
 
                 // base fee for the next block: `tip+1`
-                let pending_block_base_fee = tip
-                    .next_block_base_fee(
-                        client.chain_spec().elasticity_multiplier(),
-                        client.chain_spec().base_fee_change_denominator(),
-                    )
-                    .unwrap_or_default();
+                let pending_block_base_fee = tip.next_block_base_fee().unwrap_or_default();
 
                 let first_block = blocks.first();
                 trace!(


### PR DESCRIPTION
Reverts anton-rs/op-reth#32 since we are [fixing upstream](https://github.com/paradigmxyz/reth/pull/3992) in a way that will make this have ugly conflicts. Will redo this change after the upstream PR is merged.