### PR TITLE
feat(primitives): Add Optimism next base fee test

### DIFF
--- a/crates/primitives/src/basefee.rs
+++ b/crates/primitives/src/basefee.rs
@@ -65,4 +65,37 @@ mod tests {
             );
         }
     }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn calculate_optimism_base_fee_success() {
+        let base_fee = [
+            1000000000, 1000000000, 1000000000, 1072671875, 1059263476, 1049238967, 1049238967, 0,
+            1, 2,
+        ];
+        let gas_used = [
+            10000000, 10000000, 10000000, 9000000, 10001000, 0, 10000000, 10000000, 10000000,
+            10000000,
+        ];
+        let gas_limit = [
+            10000000, 12000000, 14000000, 10000000, 14000000, 2000000, 18000000, 18000000,
+            18000000, 18000000,
+        ];
+        let next_base_fee = [
+            1180000000, 1146666666, 1122857142, 1244299375, 1189416692, 1028254188, 1144836295, 1,
+            2, 3,
+        ];
+
+        for i in 0..base_fee.len() {
+            assert_eq!(
+                next_base_fee[i],
+                calculate_next_block_base_fee(
+                    gas_used[i],
+                    gas_limit[i],
+                    base_fee[i],
+                    crate::BaseFeeParams::optimism(),
+                )
+            );
+        }
+    }
 }


### PR DESCRIPTION
**Description**

Very small PR to add an optimism feature flag specific test for the next base fee calculation in `calculate_next_block_base_fee`.