### PR TITLE
feat: Engine API + Block Building modifications

### DIFF
--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -91,12 +91,21 @@ pub trait RethNodeCommandExt: fmt::Debug + clap::Args {
         #[cfg(feature = "optimism")]
         let payload_job_config = payload_job_config.compute_pending_block(compute_pending_block);
 
+        // The default payload builder is implemented on the unit type.
+        #[cfg(not(feature = "optimism"))]
+        let payload_builder = ();
+
+        // Optimism's payload builder is impelmented on the OptimismPayloadBuilder type.
+        #[cfg(feature = "optimism")]
+        let payload_builder = reth_basic_payload_builder::OptimismPayloadBuilder;
+
         let payload_generator = BasicPayloadJobGenerator::new(
             provider,
             pool,
             executor.clone(),
             payload_job_config,
             chain_spec,
+            payload_builder,
         );
         let (payload_service, payload_builder) = PayloadBuilderService::new(payload_generator);
 

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -73,6 +73,7 @@ pub trait RethNodeCommandExt: fmt::Debug + clap::Args {
         pool: Pool,
         executor: Tasks,
         chain_spec: Arc<ChainSpec>,
+        #[cfg(feature = "optimism")] compute_pending_block: bool,
     ) -> eyre::Result<PayloadBuilderHandle>
     where
         Conf: PayloadBuilderConfig,
@@ -80,16 +81,21 @@ pub trait RethNodeCommandExt: fmt::Debug + clap::Args {
         Pool: TransactionPool + Unpin + 'static,
         Tasks: TaskSpawner + Clone + Unpin + 'static,
     {
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(conf.interval())
+            .deadline(conf.deadline())
+            .max_payload_tasks(conf.max_payload_tasks())
+            .extradata(conf.extradata_rlp_bytes())
+            .max_gas_limit(conf.max_gas_limit());
+
+        #[cfg(feature = "optimism")]
+        let payload_job_config = payload_job_config.compute_pending_block(compute_pending_block);
+
         let payload_generator = BasicPayloadJobGenerator::new(
             provider,
             pool,
             executor.clone(),
-            BasicPayloadJobGeneratorConfig::default()
-                .interval(conf.interval())
-                .deadline(conf.deadline())
-                .max_payload_tasks(conf.max_payload_tasks())
-                .extradata(conf.extradata_rlp_bytes())
-                .max_gas_limit(conf.max_gas_limit()),
+            payload_job_config,
             chain_spec,
         );
         let (payload_service, payload_builder) = PayloadBuilderService::new(payload_generator);

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -335,6 +335,8 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
             transaction_pool.clone(),
             ctx.task_executor.clone(),
             Arc::clone(&self.chain),
+            #[cfg(feature = "optimism")]
+            self.rollup.compute_pending_block,
         )?;
 
         let max_block = if let Some(block) = self.debug.max_block {

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -72,8 +72,8 @@ pub struct NetworkConfig<C> {
     pub status: Status,
     /// Sets the hello message for the p2p handshake in RLPx
     pub hello_message: HelloMessage,
-    #[cfg(feature = "optimism")]
     /// The sequencer HTTP endpoint, if provided via CLI flag
+    #[cfg(feature = "optimism")]
     pub sequencer_endpoint: Option<String>,
 }
 
@@ -152,8 +152,8 @@ pub struct NetworkConfigBuilder {
     hello_message: Option<HelloMessage>,
     /// Head used to start set for the fork filter and status.
     head: Option<Head>,
-    #[cfg(feature = "optimism")]
     /// The sequencer HTTP endpoint, if provided via CLI flag
+    #[cfg(feature = "optimism")]
     sequencer_endpoint: Option<String>,
 }
 
@@ -351,8 +351,8 @@ impl NetworkConfigBuilder {
         }
     }
 
-    #[cfg(feature = "optimism")]
     /// Sets the sequencer HTTP endpoint.
+    #[cfg(feature = "optimism")]
     pub fn sequencer_endpoint(mut self, endpoint: Option<String>) -> Self {
         self.sequencer_endpoint = endpoint;
         self

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -337,7 +337,16 @@ where
                         tx,
                     )
                 }));
-                this.pending_block = Some(PendingPayload { _cancel, payload: rx });
+
+                #[cfg(not(feature = "optimism"))]
+                {
+                    this.pending_block = Some(PendingPayload { _cancel, payload: rx });
+                }
+
+                #[cfg(feature = "optimism")]
+                if this.config.compute_pending_block {
+                    this.pending_block = Some(PendingPayload { _cancel, payload: rx });
+                }
             }
         }
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -696,7 +696,6 @@ fn build_payload<Pool, Client>(
                         success: result.is_success(),
                         cumulative_gas_used,
                         logs: result.logs().into_iter().map(into_reth_log).collect(),
-                        // TODO(clabby): Implement effective nonce
                         #[cfg(feature = "optimism")]
                         deposit_nonce: None,
                     },
@@ -779,7 +778,6 @@ fn build_payload<Pool, Client>(
                     success: result.is_success(),
                     cumulative_gas_used,
                     logs: result.logs().into_iter().map(into_reth_log).collect(),
-                    // TODO(clabby): Implement effective nonce
                     #[cfg(feature = "optimism")]
                     deposit_nonce: None,
                 },

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -630,7 +630,7 @@ fn build_payload<Pool, Client>(
 
         #[cfg(feature = "optimism")]
         let block_gas_limit: u64 =
-            if let Some(gas_limit) = attributes.gas_limit { gas_limit } else { block_gas_limit };
+            attributes.gas_limit.unwrap_or(block_gas_limit);
 
         let base_fee = initialized_block_env.basefee.to::<u64>();
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -187,6 +187,9 @@ pub struct BasicPayloadJobGeneratorConfig {
     deadline: Duration,
     /// Maximum number of tasks to spawn for building a payload.
     max_payload_tasks: usize,
+    /// The rollup's compute pending block configuration option.
+    #[cfg(feature = "optimism")]
+    compute_pending_block: bool,
 }
 
 // === impl BasicPayloadJobGeneratorConfig ===
@@ -230,6 +233,15 @@ impl BasicPayloadJobGeneratorConfig {
         self.max_gas_limit = max_gas_limit;
         self
     }
+
+    /// Sets the compute pending block configuration option.
+    ///
+    /// Defaults to `false`.
+    #[cfg(feature = "optimism")]
+    pub fn compute_pending_block(mut self, compute_pending_block: bool) -> Self {
+        self.compute_pending_block = compute_pending_block;
+        self
+    }
 }
 
 impl Default for BasicPayloadJobGeneratorConfig {
@@ -243,6 +255,8 @@ impl Default for BasicPayloadJobGeneratorConfig {
             // 12s slot time
             deadline: SLOT_DURATION,
             max_payload_tasks: 3,
+            #[cfg(feature = "optimism")]
+            compute_pending_block: false,
         }
     }
 }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -629,8 +629,7 @@ fn build_payload<Pool, Client>(
         let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
 
         #[cfg(feature = "optimism")]
-        let block_gas_limit: u64 =
-            attributes.gas_limit.unwrap_or(block_gas_limit);
+        let block_gas_limit: u64 = attributes.gas_limit.unwrap_or(block_gas_limit);
 
         let base_fee = initialized_block_env.basefee.to::<u64>();
 
@@ -875,8 +874,7 @@ where
     let block_gas_limit: u64 = initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX);
 
     #[cfg(feature = "optimism")]
-    let block_gas_limit: u64 =
-        if let Some(gas_limit) = attributes.gas_limit { gas_limit } else { block_gas_limit };
+    let block_gas_limit: u64 = attributes.gas_limit.unwrap_or(block_gas_limit);
 
     let WithdrawalsOutcome { withdrawals_root, withdrawals } = commit_withdrawals(
         &mut db,

--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -66,7 +66,7 @@ where
             let sequencer_tx = sequencer_tx
                 .clone()
                 .try_into_ecrecovered()
-                .map_err(|_| PayloadBuilderError::DepositTransactionRecoverFailed)?;
+                .map_err(|_| PayloadBuilderError::TransactionEcRecoverFailed)?;
 
             // Configure the environment for the block.
             let env = Env {

--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -144,93 +144,86 @@ where
         }
     }
 
-    if !attributes.no_tx_pool {
-        while let Some(pool_tx) = best_txs.next() {
-            // ensure we still have capacity for this transaction
-            if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
-                // we can't fit this transaction into the block, so we need to mark it as invalid
-                // which also removes all dependent transaction from the iterator before we can
-                // continue
-                best_txs.mark_invalid(&pool_tx);
-                continue
-            }
+    while let Some(pool_tx) = best_txs.next() {
+        // ensure we still have capacity for this transaction
+        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+            // we can't fit this transaction into the block, so we need to mark it as invalid
+            // which also removes all dependent transaction from the iterator before we can
+            // continue
+            best_txs.mark_invalid(&pool_tx);
+            continue
+        }
 
-            // check if the job was cancelled, if so we can exit early
-            if cancel.is_cancelled() {
-                return Ok(BuildOutcome::Cancelled)
-            }
+        // check if the job was cancelled, if so we can exit early
+        if cancel.is_cancelled() {
+            return Ok(BuildOutcome::Cancelled)
+        }
 
-            // convert tx to a signed transaction
-            let tx = pool_tx.to_recovered_transaction();
+        // convert tx to a signed transaction
+        let tx = pool_tx.to_recovered_transaction();
 
-            // Configure the environment for the block.
-            let env = Env {
-                cfg: initialized_cfg.clone(),
-                block: initialized_block_env.clone(),
-                tx: tx_env_with_recovered(&tx),
-            };
+        // Configure the environment for the block.
+        let env = Env {
+            cfg: initialized_cfg.clone(),
+            block: initialized_block_env.clone(),
+            tx: tx_env_with_recovered(&tx),
+        };
 
-            let mut evm = revm::EVM::with_env(env);
-            evm.database(&mut db);
+        let mut evm = revm::EVM::with_env(env);
+        evm.database(&mut db);
 
-            let ResultAndState { result, state } = match evm.transact() {
-                Ok(res) => res,
-                Err(err) => {
-                    match err {
-                        EVMError::Transaction(err) => {
-                            if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
-                                // if the nonce is too low, we can skip this transaction
-                                trace!(?err, ?tx, "skipping nonce too low transaction");
-                            } else {
-                                // if the transaction is invalid, we can skip it and all of its
-                                // descendants
-                                trace!(
-                                    ?err,
-                                    ?tx,
-                                    "skipping invalid transaction and its descendants"
-                                );
-                                best_txs.mark_invalid(&pool_tx);
-                            }
-                            continue
+        let ResultAndState { result, state } = match evm.transact() {
+            Ok(res) => res,
+            Err(err) => {
+                match err {
+                    EVMError::Transaction(err) => {
+                        if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(?err, ?tx, "skipping nonce too low transaction");
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(?err, ?tx, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(&pool_tx);
                         }
-                        err => {
-                            // this is an error that we should treat as fatal for this attempt
-                            return Err(PayloadBuilderError::EvmExecutionError(err))
-                        }
+                        continue
+                    }
+                    err => {
+                        // this is an error that we should treat as fatal for this attempt
+                        return Err(PayloadBuilderError::EvmExecutionError(err))
                     }
                 }
-            };
+            }
+        };
 
-            let gas_used = result.gas_used();
+        let gas_used = result.gas_used();
 
-            // commit changes
-            commit_state_changes(&mut db, &mut post_state, block_number, state, true);
+        // commit changes
+        commit_state_changes(&mut db, &mut post_state, block_number, state, true);
 
-            // add gas used by the transaction to cumulative gas used, before creating the receipt
-            cumulative_gas_used += gas_used;
+        // add gas used by the transaction to cumulative gas used, before creating the receipt
+        cumulative_gas_used += gas_used;
 
-            // Push transaction changeset and calculate header bloom filter for receipt.
-            post_state.add_receipt(
-                block_number,
-                Receipt {
-                    tx_type: tx.tx_type(),
-                    success: result.is_success(),
-                    cumulative_gas_used,
-                    logs: result.logs().into_iter().map(into_reth_log).collect(),
-                    #[cfg(feature = "optimism")]
-                    deposit_nonce: None,
-                },
-            );
+        // Push transaction changeset and calculate header bloom filter for receipt.
+        post_state.add_receipt(
+            block_number,
+            Receipt {
+                tx_type: tx.tx_type(),
+                success: result.is_success(),
+                cumulative_gas_used,
+                logs: result.logs().into_iter().map(into_reth_log).collect(),
+                #[cfg(feature = "optimism")]
+                deposit_nonce: None,
+            },
+        );
 
-            // update add to total fees
-            let miner_fee = tx
-                .effective_tip_per_gas(base_fee)
-                .expect("fee is always valid; execution succeeded");
-            total_fees += U256::from(miner_fee) * U256::from(gas_used);
+        // update add to total fees
+        let miner_fee =
+            tx.effective_tip_per_gas(base_fee).expect("fee is always valid; execution succeeded");
+        total_fees += U256::from(miner_fee) * U256::from(gas_used);
 
-            // append transaction to the list of executed transactions
-            executed_txs.push(tx.into_signed());
-        }
+        // append transaction to the list of executed transactions
+        executed_txs.push(tx.into_signed());
     }
 
     // check if we have a better block

--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -1,0 +1,308 @@
+//! Optimism's [PayloadBuilder] implementation.
+
+use super::*;
+
+/// Constructs an Ethereum transaction payload from the transactions sent through the
+/// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
+/// the payload attributes, the transaction pool will be ignored and the only transactions
+/// included in the payload will be those sent through the attributes.
+///
+/// Given build arguments including an Ethereum client, transaction pool,
+/// and configuration, this function creates a transaction payload. Returns
+/// a result indicating success with the payload or an error in case of failure.
+#[inline]
+fn optimism_payload_builder<Pool, Client>(
+    args: BuildArguments<Pool, Client>,
+) -> Result<BuildOutcome, PayloadBuilderError>
+where
+    Client: StateProviderFactory,
+    Pool: TransactionPool,
+{
+    let BuildArguments { client, pool, mut cached_reads, config, cancel, best_payload } = args;
+
+    let extra_data = config.extra_data();
+    let PayloadConfig {
+        initialized_block_env,
+        initialized_cfg,
+        parent_block,
+        attributes,
+        chain_spec,
+        ..
+    } = config;
+
+    debug!(parent_hash=?parent_block.hash, parent_number=parent_block.number, "building new payload");
+
+    let state = State::new(client.state_by_block_hash(parent_block.hash)?);
+    let mut db = CacheDB::new(cached_reads.as_db(&state));
+    let mut post_state = PostState::default();
+
+    let mut cumulative_gas_used = 0;
+    let block_gas_limit: u64 = attributes
+        .gas_limit
+        .unwrap_or(initialized_block_env.gas_limit.try_into().unwrap_or(u64::MAX));
+    let base_fee = initialized_block_env.basefee.to::<u64>();
+
+    let mut executed_txs = Vec::new();
+    let mut best_txs = pool.best_transactions_with_base_fee(base_fee);
+
+    let mut total_fees = U256::ZERO;
+
+    let block_number = initialized_block_env.number.to::<u64>();
+
+    // Transactions sent via the payload attributes are force included at the top of the block, in
+    // the order that they were sent in.
+    #[cfg(feature = "optimism")]
+    {
+        for sequencer_tx in attributes.transactions {
+            // Check if the job was cancelled, if so we can exit early.
+            if cancel.is_cancelled() {
+                return Ok(BuildOutcome::Cancelled)
+            }
+
+            // Convert the transaction to a [TransactionSignedEcRecovered]. This is
+            // purely for the purposes of utilizing the [tx_env_with_recovered] function.
+            // Deposit transactions do not have signatures, so if the tx is a deposit, this
+            // will just pull in its `from` address.
+            let sequencer_tx = sequencer_tx
+                .clone()
+                .try_into_ecrecovered()
+                .map_err(|_| PayloadBuilderError::DepositTransactionRecoverFailed)?;
+
+            // Configure the environment for the block.
+            let env = Env {
+                cfg: initialized_cfg.clone(),
+                block: initialized_block_env.clone(),
+                tx: tx_env_with_recovered(&sequencer_tx),
+            };
+
+            let mut evm = revm::EVM::with_env(env);
+            evm.database(&mut db);
+
+            let ResultAndState { result, state } = match evm.transact() {
+                Ok(res) => res,
+                Err(err) => {
+                    // TODO(clabby): This could be an issue - deposit transactions should always be
+                    // included with a receipt regardless of if there was an error or not. The
+                    // sequencer performs some basic validation on the transactions it sends prior
+                    // to sending a fork choice update, so this shouldn't be an issue, but we may
+                    // want to revisit this.
+                    match err {
+                        EVMError::Transaction(err) => {
+                            if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
+                                // if the nonce is too low, we can skip this transaction
+                                trace!(?err, ?sequencer_tx, "skipping nonce too low transaction");
+                            } else {
+                                // if the transaction is invalid, we can skip it and all of its
+                                // descendants
+                                trace!(
+                                    ?err,
+                                    ?sequencer_tx,
+                                    "skipping invalid transaction and its descendants"
+                                );
+                            }
+                            continue
+                        }
+                        err => {
+                            // this is an error that we should treat as fatal for this attempt
+                            return Err(PayloadBuilderError::EvmExecutionError(err))
+                        }
+                    }
+                }
+            };
+
+            // commit changes
+            commit_state_changes(&mut db, &mut post_state, block_number, state, true);
+
+            // Push transaction changeset and calculate header bloom filter for receipt.
+            post_state.add_receipt(
+                block_number,
+                Receipt {
+                    tx_type: sequencer_tx.tx_type(),
+                    success: result.is_success(),
+                    cumulative_gas_used,
+                    logs: result.logs().into_iter().map(into_reth_log).collect(),
+                    deposit_nonce: if chain_spec
+                        .is_fork_active_at_timestamp(Hardfork::Regolith, attributes.timestamp) &&
+                        sequencer_tx.is_deposit()
+                    {
+                        // Recovering the signer from the deposit transaction is only fetching
+                        // the `from` address. Deposit transactions have no signature.
+                        let from = sequencer_tx.signer();
+                        let account = db.load_account(from)?;
+                        // The deposit nonce is the account's nonce - 1. The account's nonce
+                        // was incremented during the execution of the deposit transaction
+                        // above.
+                        Some(account.info.nonce.saturating_sub(1))
+                    } else {
+                        None
+                    },
+                },
+            );
+
+            // append transaction to the list of executed transactions
+            executed_txs.push(sequencer_tx.into_signed());
+        }
+    }
+
+    if !attributes.no_tx_pool {
+        while let Some(pool_tx) = best_txs.next() {
+            // ensure we still have capacity for this transaction
+            if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+                // we can't fit this transaction into the block, so we need to mark it as invalid
+                // which also removes all dependent transaction from the iterator before we can
+                // continue
+                best_txs.mark_invalid(&pool_tx);
+                continue
+            }
+
+            // check if the job was cancelled, if so we can exit early
+            if cancel.is_cancelled() {
+                return Ok(BuildOutcome::Cancelled)
+            }
+
+            // convert tx to a signed transaction
+            let tx = pool_tx.to_recovered_transaction();
+
+            // Configure the environment for the block.
+            let env = Env {
+                cfg: initialized_cfg.clone(),
+                block: initialized_block_env.clone(),
+                tx: tx_env_with_recovered(&tx),
+            };
+
+            let mut evm = revm::EVM::with_env(env);
+            evm.database(&mut db);
+
+            let ResultAndState { result, state } = match evm.transact() {
+                Ok(res) => res,
+                Err(err) => {
+                    match err {
+                        EVMError::Transaction(err) => {
+                            if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
+                                // if the nonce is too low, we can skip this transaction
+                                trace!(?err, ?tx, "skipping nonce too low transaction");
+                            } else {
+                                // if the transaction is invalid, we can skip it and all of its
+                                // descendants
+                                trace!(
+                                    ?err,
+                                    ?tx,
+                                    "skipping invalid transaction and its descendants"
+                                );
+                                best_txs.mark_invalid(&pool_tx);
+                            }
+                            continue
+                        }
+                        err => {
+                            // this is an error that we should treat as fatal for this attempt
+                            return Err(PayloadBuilderError::EvmExecutionError(err))
+                        }
+                    }
+                }
+            };
+
+            let gas_used = result.gas_used();
+
+            // commit changes
+            commit_state_changes(&mut db, &mut post_state, block_number, state, true);
+
+            // add gas used by the transaction to cumulative gas used, before creating the receipt
+            cumulative_gas_used += gas_used;
+
+            // Push transaction changeset and calculate header bloom filter for receipt.
+            post_state.add_receipt(
+                block_number,
+                Receipt {
+                    tx_type: tx.tx_type(),
+                    success: result.is_success(),
+                    cumulative_gas_used,
+                    logs: result.logs().into_iter().map(into_reth_log).collect(),
+                    #[cfg(feature = "optimism")]
+                    deposit_nonce: None,
+                },
+            );
+
+            // update add to total fees
+            let miner_fee = tx
+                .effective_tip_per_gas(base_fee)
+                .expect("fee is always valid; execution succeeded");
+            total_fees += U256::from(miner_fee) * U256::from(gas_used);
+
+            // append transaction to the list of executed transactions
+            executed_txs.push(tx.into_signed());
+        }
+    }
+
+    // check if we have a better block
+    if !is_better_payload(best_payload.as_deref(), total_fees) {
+        // can skip building the block
+        return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
+    }
+
+    let WithdrawalsOutcome { withdrawals_root, withdrawals } = commit_withdrawals(
+        &mut db,
+        &mut post_state,
+        &chain_spec,
+        block_number,
+        attributes.timestamp,
+        attributes.withdrawals,
+    )?;
+
+    let receipts_root = post_state.receipts_root(block_number);
+    let logs_bloom = post_state.logs_bloom(block_number);
+
+    // calculate the state root
+    let state_root = state.state().state_root(post_state)?;
+
+    // create the block header
+    let transactions_root = proofs::calculate_transaction_root(&executed_txs);
+
+    let header = Header {
+        parent_hash: parent_block.hash,
+        ommers_hash: EMPTY_OMMER_ROOT,
+        beneficiary: initialized_block_env.coinbase,
+        state_root,
+        transactions_root,
+        receipts_root,
+        withdrawals_root,
+        logs_bloom,
+        timestamp: attributes.timestamp,
+        mix_hash: attributes.prev_randao,
+        nonce: BEACON_NONCE,
+        base_fee_per_gas: Some(base_fee),
+        number: parent_block.number + 1,
+        gas_limit: block_gas_limit,
+        difficulty: U256::ZERO,
+        gas_used: cumulative_gas_used,
+        extra_data,
+        blob_gas_used: None,
+        excess_blob_gas: None,
+    };
+
+    // seal the block
+    let block = Block { header, body: executed_txs, ommers: vec![], withdrawals };
+
+    let sealed_block = block.seal_slow();
+    Ok(BuildOutcome::Better {
+        payload: BuiltPayload::new(attributes.id, sealed_block, total_fees),
+        cached_reads,
+    })
+}
+
+/// Optimism's payload builder
+#[derive(Clone)]
+pub struct OptimismPayloadBuilder;
+
+/// Implementation of the [PayloadBuilder] trait for [OptimismPayloadBuilder].
+impl<Pool, Client> PayloadBuilder<Pool, Client> for OptimismPayloadBuilder
+where
+    Client: StateProviderFactory,
+    Pool: TransactionPool,
+{
+    fn try_build(
+        &self,
+        args: BuildArguments<Pool, Client>,
+    ) -> Result<BuildOutcome, PayloadBuilderError> {
+        optimism_payload_builder(args)
+    }
+}

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -4,6 +4,10 @@ use reth_primitives::H256;
 use revm_primitives::EVMError;
 use tokio::sync::oneshot;
 
+// Imported for rustdoc on `DepositTransactionRecoverFailed` error.
+#[allow(unused_imports)]
+use reth_primitives::TransactionSignedEcRecovered;
+
 /// Possible error variants during payload building.
 #[derive(Debug, thiserror::Error)]
 pub enum PayloadBuilderError {

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -22,6 +22,10 @@ pub enum PayloadBuilderError {
     /// Thrown if the payload requests withdrawals before Shanghai activation.
     #[error("withdrawals set before Shanghai activation")]
     WithdrawalsBeforeShanghai,
+    /// Thrown when a deposit transaction fails to convert to a [TransactionSignedEcRecovered].
+    #[cfg(feature = "optimism")]
+    #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
+    DepositTransactionRecoverFailed,
 }
 
 impl From<oneshot::error::RecvError> for PayloadBuilderError {

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -22,11 +22,11 @@ pub enum PayloadBuilderError {
     /// Thrown if the payload requests withdrawals before Shanghai activation.
     #[error("withdrawals set before Shanghai activation")]
     WithdrawalsBeforeShanghai,
-    /// Thrown when a deposit transaction fails to convert to a
+    /// Thrown when a transaction fails to convert to a
     /// [reth_primitives::TransactionSignedEcRecovered].
     #[cfg(feature = "optimism")]
     #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
-    DepositTransactionRecoverFailed,
+    TransactionEcRecoverFailed,
 }
 
 impl From<oneshot::error::RecvError> for PayloadBuilderError {

--- a/crates/payload/builder/src/error.rs
+++ b/crates/payload/builder/src/error.rs
@@ -4,10 +4,6 @@ use reth_primitives::H256;
 use revm_primitives::EVMError;
 use tokio::sync::oneshot;
 
-// Imported for rustdoc on `DepositTransactionRecoverFailed` error.
-#[allow(unused_imports)]
-use reth_primitives::TransactionSignedEcRecovered;
-
 /// Possible error variants during payload building.
 #[derive(Debug, thiserror::Error)]
 pub enum PayloadBuilderError {
@@ -26,7 +22,8 @@ pub enum PayloadBuilderError {
     /// Thrown if the payload requests withdrawals before Shanghai activation.
     #[error("withdrawals set before Shanghai activation")]
     WithdrawalsBeforeShanghai,
-    /// Thrown when a deposit transaction fails to convert to a [TransactionSignedEcRecovered].
+    /// Thrown when a deposit transaction fails to convert to a
+    /// [reth_primitives::TransactionSignedEcRecovered].
     #[cfg(feature = "optimism")]
     #[error("failed to convert deposit transaction to TransactionSignedEcRecovered")]
     DepositTransactionRecoverFailed,

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -242,6 +242,13 @@ where
                         if this.contains_payload(id) {
                             warn!(%id, parent = ?attr.parent, "Payload job already in progress, ignoring.");
                         } else {
+                            // Don't start the payload job if there is no tx pool to pull from.
+                            #[cfg(feature = "optimism")]
+                            if attr.no_tx_pool {
+                                let _ = tx.send(res);
+                                continue
+                            }
+
                             // no job for this payload yet, create one
                             match this.generator.new_payload_job(attr) {
                                 Ok(job) => {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -243,6 +243,8 @@ where
                             warn!(%id, parent = ?attr.parent, "Payload job already in progress, ignoring.");
                         } else {
                             // Don't start the payload job if there is no tx pool to pull from.
+                            // TODO(clabby): We probably still want to start the job here and just
+                            // ignore pooled transactions within the builder itself.
                             #[cfg(feature = "optimism")]
                             if attr.no_tx_pool {
                                 let _ = tx.send(res);

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -323,14 +323,10 @@ where
                             cumulative_gas_used,
                             logs: vec![],
                             // Deposit nonces are only recorded after Regolith
-                            deposit_nonce: if self
+                            deposit_nonce: self
                                 .chain_spec
                                 .is_fork_active_at_timestamp(Hardfork::Regolith, block.timestamp)
-                            {
-                                Some(old_sender_info.nonce)
-                            } else {
-                                None
-                            },
+                                .then_some(old_sender_info.nonce),
                         },
                     );
                     continue
@@ -387,15 +383,11 @@ where
                         cumulative_gas_used,
                         logs,
                         // Deposit nonce is only recorded after Regolith for deposit transactions.
-                        deposit_nonce: if self
+                        deposit_nonce: (self
                             .chain_spec
                             .is_fork_active_at_timestamp(Hardfork::Regolith, block.timestamp) &&
-                            transaction.is_deposit()
-                        {
-                            Some(old_sender_info.nonce)
-                        } else {
-                            None
-                        },
+                            transaction.is_deposit())
+                        .then_some(old_sender_info.nonce),
                     },
                 );
             }

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -385,16 +385,6 @@ where
 
             #[cfg(not(feature = "optimism"))]
             {
-                // The sum of the transaction’s gas limit, Tg, and the gas utilised in this block
-                // prior, must be no greater than the block’s gasLimit.
-                let block_available_gas = block.header.gas_limit - cumulative_gas_used;
-                if transaction.gas_limit() > block_available_gas {
-                    return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                        transaction_gas_limit: transaction.gas_limit(),
-                        block_available_gas,
-                    }
-                    .into())
-                }
                 // Execute transaction.
                 let ResultAndState { result, state } = self.transact(transaction, sender)?;
 

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -322,7 +322,15 @@ where
                             success: false,
                             cumulative_gas_used,
                             logs: vec![],
-                            deposit_nonce: None,
+                            // Deposit nonces are only recorded after Regolith
+                            deposit_nonce: if self
+                                .chain_spec
+                                .is_fork_active_at_timestamp(Hardfork::Regolith, block.timestamp)
+                            {
+                                Some(old_sender_info.nonce)
+                            } else {
+                                None
+                            },
                         },
                     );
                     continue
@@ -378,7 +386,16 @@ where
                         success: result.is_success(),
                         cumulative_gas_used,
                         logs,
-                        deposit_nonce: None,
+                        // Deposit nonce is only recorded after Regolith for deposit transactions.
+                        deposit_nonce: if self
+                            .chain_spec
+                            .is_fork_active_at_timestamp(Hardfork::Regolith, block.timestamp) &&
+                            transaction.is_deposit()
+                        {
+                            Some(old_sender_info.nonce)
+                        } else {
+                            None
+                        },
                     },
                 );
             }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -107,7 +107,13 @@ where
                 attrs.timestamp.as_u64(),
                 attrs.withdrawals.is_some(),
             )?;
+
+            #[cfg(feature = "optimism")]
+            if attrs.gas_limit.is_none() && self.inner.chain_spec.optimism {
+                return Err(EngineApiError::MissingGasLimitInPayloadAttributes)
+            }
         }
+
         Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs).await?)
     }
 


### PR DESCRIPTION
## Overview

Adds the changes to the engine API and block building logic defined in the [execution engine specifications](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine-api) in the optimism monorepo.

### Checklist
- [x] Payload attributes extra fields
  - [x] Payload ID modifications
  - [x] No tx pool attribute handler
  - [x] Gas limit attribute check
- [x] Payload builder modifications
  - [x] Compute pending block CLI option handlers
    - [x] Pull in `rollup.compute_pending_block` CLI flag into the `BasicPayloadJobGeneratorConfig`
    - [x] Handlers for if `compute_pending_block` is false in the payload builder's pending block functionality.
  - [x] Block building modifications (empty and with txs)
  - [x] The payload build functions are now generic with https://github.com/paradigmxyz/reth/pull/4193 & https://github.com/paradigmxyz/reth/pull/4153. We'll want to break out our changes into our own builder.