### PR TITLE
fix(primitives): Update Optimism Goerli Chain Spec with Bedrock Hardfork

### DIFF
--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -258,6 +258,7 @@ pub static OP_GOERLI: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
                 Hardfork::Paris,
                 ForkCondition::TTD { fork_block: Some(0), total_difficulty: U256::from(0) },
             ),
+            (Hardfork::Bedrock, ForkCondition::Block(4061224)),
             (Hardfork::Regolith, ForkCondition::Timestamp(1679079600)),
         ]),
         base_fee_params: BaseFeeParams::optimism(),


### PR DESCRIPTION
**Description**

Updates the Optimism goerli chain spec to add the bedrock hard fork.

This is a block-based fork condition and is based on the optimism goerli rollup config in the [optimism monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/chaincfg/chains.go#L51). Since the committed code in trunk is bedrock, we take this L2 genesis block number as the bedrock transition block.