### PR TITLE
fix(primitives): Add optional nonce to `DepositTx` for Regolith

### DIFF
--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -20,6 +20,8 @@ pub struct TxDeposit {
     /// The address of the recipient account, or the null (zero-length) address if the deposited
     /// transaction is a contract creation.
     pub to: TransactionKind,
+    /// Optional nonce field
+    pub nonce: Option<u64>,
     /// The ETH value to mint on L2.
     pub mint: Option<u128>,
     ///  The ETH value to send to the recipient account.
@@ -40,6 +42,7 @@ impl TxDeposit {
         mem::size_of::<H256>() + // source_hash
         mem::size_of::<Address>() + // from
         self.to.size() + // to
+        mem::size_of::<Option<u64>>() + // nonce
         mem::size_of::<Option<u128>>() + // mint
         mem::size_of::<u128>() + // value
         mem::size_of::<u64>() + // gas_limit

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -322,7 +322,7 @@ where
                             success: false,
                             cumulative_gas_used,
                             logs: vec![],
-                            deposit_nonce: Some(transaction.nonce()),
+                            deposit_nonce: transaction.effective_nonce(),
                         },
                     );
                     continue
@@ -378,7 +378,11 @@ where
                         success: result.is_success(),
                         cumulative_gas_used,
                         logs,
-                        deposit_nonce: Some(transaction.nonce()),
+                        deposit_nonce: if transaction.is_deposit() {
+                            transaction.effective_nonce()
+                        } else {
+                            None
+                        },
                     },
                 );
             }


### PR DESCRIPTION
## Overview

Adds an optional nonce field to `TxDeposit`, which was added in the Regolith hardfork. Must be `None` prior to the Regolith hardfork.

Will be used to hydrate the receipts in the `User API Enhancements` section of the `op-geth` diff. https://github.com/ethereum-optimism/op-geth/blob/8f8af46ec728a79137d449891fc1827e1763cd7e/core/types/receipt.go 