### PR TITLE
feat(transaction-pool): Tx Pool Cost Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6199,6 +6199,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives",
  "reth-provider",
+ "reth-revm",
  "reth-rlp",
  "reth-tasks",
  "serde",

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -12,9 +12,6 @@ use reth_primitives::{
 use reth_provider::{AccountReader, HeaderProvider, WithdrawalsProvider};
 use std::collections::{hash_map::Entry, HashMap};
 
-#[cfg(feature = "optimism")]
-use reth_primitives::TxDeposit;
-
 /// Validate header standalone
 pub fn validate_header_standalone(
     header: &SealedHeader,
@@ -125,7 +122,7 @@ pub fn validate_transaction_regarding_header(
             Some(*chain_id)
         }
         #[cfg(feature = "optimism")]
-        Transaction::Deposit(TxDeposit { .. }) => None,
+        Transaction::Deposit(_) => None,
     };
     if let Some(chain_id) = chain_id {
         if chain_id != chain_spec.chain().id() {

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -28,5 +28,10 @@ reth-rlp.workspace = true
 once_cell = "1.17.0"
 
 [features]
-optimism = ["reth-primitives/optimism", "reth-revm-primitives/optimism"]
+optimism = [
+  "reth-primitives/optimism",
+  "reth-revm-primitives/optimism",
+  "reth-consensus-common/optimism",
+  "reth-interfaces/optimism",
+]
 

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -251,9 +251,10 @@ where
             #[cfg(feature = "optimism")]
             {
                 let db = self.db();
-                let l1_cost = l1_block_info
-                    .as_ref()
-                    .map(|l1_block_info| l1_block_info.calculate_tx_l1_cost(transaction));
+                let l1_cost = l1_block_info.as_ref().map(|l1_block_info| {
+                    l1_block_info
+                        .calculate_tx_l1_cost(transaction.input(), transaction.is_deposit())
+                });
 
                 let sender_account =
                     db.load_account(sender).map_err(|_| BlockExecutionError::ProviderError)?;

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use reth_interfaces::executor;
-use reth_primitives::{Address, Block, TransactionKind, TransactionSigned, U256};
+use reth_primitives::{Address, Block, Bytes, TransactionKind, U256};
 
 const L1_FEE_RECIPIENT: &str = "0x420000000000000000000000000000000000001A";
 const BASE_FEE_RECIPIENT: &str = "0x4200000000000000000000000000000000000019";
@@ -84,12 +84,12 @@ impl TryFrom<&Block> for L1BlockInfo {
 
 impl L1BlockInfo {
     /// Calculate the gas cost of a transaction based on L1 block data posted on L2
-    pub fn calculate_tx_l1_cost(&self, tx: &TransactionSigned) -> U256 {
-        let rollup_data_gas_cost = U256::from(tx.input().iter().fold(0, |acc, byte| {
+    pub fn calculate_tx_l1_cost(&self, input: &Bytes, is_deposit: bool) -> U256 {
+        let rollup_data_gas_cost = U256::from(input.iter().fold(0, |acc, byte| {
             acc + if *byte == 0x00 { ZERO_BYTE_COST } else { NON_ZERO_BYTE_COST }
         }));
 
-        if tx.is_deposit() || rollup_data_gas_cost == U256::ZERO {
+        if is_deposit || rollup_data_gas_cost == U256::ZERO {
             return U256::ZERO
         }
 

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -24,6 +24,7 @@ reth-interfaces.workspace = true
 reth-rlp.workspace = true
 reth-metrics.workspace = true
 reth-tasks.workspace = true
+reth-revm.workspace = true
 
 # async/futures
 async-trait.workspace = true
@@ -59,7 +60,12 @@ default = ["serde"]
 serde = ["dep:serde"]
 test-utils = ["rand", "paste", "serde"]
 arbitrary = ["proptest", "reth-primitives/arbitrary"]
-optimism = ["reth-primitives/optimism"]
+optimism = [
+    "reth-primitives/optimism",
+    "reth-revm/optimism",
+    "reth-provider/test-utils",
+    "reth-provider/optimism",
+]
 
 [[bench]]
 name = "reorder"

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -92,10 +92,10 @@
 //!
 //! ```
 //! use reth_primitives::MAINNET;
-//! use reth_provider::{ChainSpecProvider, StateProviderFactory};
+//! use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 //! use reth_tasks::TokioTaskExecutor;
 //! use reth_transaction_pool::{EthTransactionValidator, Pool, TransactionPool};
-//!  async fn t<C>(client: C)  where C: StateProviderFactory + ChainSpecProvider + Clone + 'static{
+//!  async fn t<C>(client: C)  where C: StateProviderFactory + BlockReaderIdExt + ChainSpecProvider + Clone + 'static{
 //!     let pool = Pool::eth_pool(
 //!         EthTransactionValidator::new(client, MAINNET.clone(), TokioTaskExecutor::default()),
 //!         Default::default(),
@@ -263,7 +263,7 @@ where
 impl<Client>
     Pool<EthTransactionValidator<Client, PooledTransaction>, CoinbaseTipOrdering<PooledTransaction>>
 where
-    Client: StateProviderFactory + Clone + 'static,
+    Client: StateProviderFactory + reth_provider::BlockReaderIdExt + Clone + 'static,
 {
     /// Returns a new [Pool] that uses the default [EthTransactionValidator] when validating
     /// [PooledTransaction]s and ords via [CoinbaseTipOrdering]
@@ -271,11 +271,11 @@ where
     /// # Example
     ///
     /// ```
-    /// use reth_provider::StateProviderFactory;
+    /// use reth_provider::{BlockReaderIdExt, StateProviderFactory};
     /// use reth_primitives::MAINNET;
     /// use reth_tasks::TokioTaskExecutor;
     /// use reth_transaction_pool::{EthTransactionValidator, Pool};
-    /// # fn t<C>(client: C)  where C: StateProviderFactory + Clone + 'static{
+    /// # fn t<C>(client: C)  where C: StateProviderFactory + BlockReaderIdExt + Clone + 'static {
     ///     let pool = Pool::eth_pool(
     ///         EthTransactionValidator::new(client, MAINNET.clone(), TokioTaskExecutor::default()),
     ///         Default::default(),

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -10,7 +10,7 @@ use crate::{
     TransactionOrigin, TransactionPool, TransactionValidationOutcome, TransactionValidator,
     ValidPoolTransaction,
 };
-use reth_primitives::{Address, TxHash};
+use reth_primitives::{Address, InvalidTransactionError, TxHash};
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 use tokio::sync::{mpsc, mpsc::Receiver};
 
@@ -181,6 +181,14 @@ impl<T: PoolTransaction> TransactionValidator for MockTransactionValidator<T> {
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
+        #[cfg(feature = "optimism")]
+        if transaction.is_deposit() {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidTransactionError::TxTypeNotSupported.into(),
+            )
+        }
+
         TransactionValidationOutcome::Valid {
             balance: Default::default(),
             state_nonce: 0,

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -12,7 +12,7 @@ use rand::{
     prelude::Distribution,
 };
 use reth_primitives::{
-    constants::MIN_PROTOCOL_BASE_FEE, hex, Address, FromRecoveredTransaction,
+    constants::MIN_PROTOCOL_BASE_FEE, hex, Address, Bytes, FromRecoveredTransaction,
     IntoRecoveredTransaction, Signature, Transaction, TransactionKind, TransactionSigned,
     TransactionSignedEcRecovered, TxEip1559, TxEip2930, TxEip4844, TxHash, TxLegacy, TxType, H256,
     U128, U256,
@@ -28,9 +28,6 @@ use reth_primitives::DEPOSIT_TX_TYPE_ID;
 
 #[cfg(feature = "optimism")]
 use reth_primitives::TxDeposit;
-
-#[cfg(feature = "optimism")]
-use reth_primitives::Bytes;
 
 /// Create an empty `TxPool`
 pub(crate) fn mock_tx_pool() -> MockTxPool {
@@ -51,17 +48,25 @@ macro_rules! set_value {
             MockTransaction::Eip4844 { ref mut $field, .. } => {
                 *$field = new_value;
             }
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => {
+                panic!("not implemented")
+            }
         }
     };
 }
 
-/// Sets the value fo the field
+/// Gets the value for the field
 macro_rules! get_value {
     ($this:ident => $field:ident) => {
         match $this {
             MockTransaction::Legacy { $field, .. } => $field,
             MockTransaction::Eip1559 { $field, .. } => $field,
             MockTransaction::Eip4844 { $field, .. } => $field,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => {
+                panic!("not implemented")
+            }
         }
     };
 }
@@ -123,6 +128,8 @@ pub enum MockTransaction {
         to: TransactionKind,
         value: U256,
     },
+    #[cfg(feature = "optimism")]
+    Deposit(TxDeposit),
 }
 
 // === impl MockTransaction ===
@@ -232,6 +239,10 @@ impl MockTransaction {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => {
+                panic!("not implemented")
+            }
         }
         self
     }
@@ -257,6 +268,10 @@ impl MockTransaction {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => {
+                panic!("not implemented")
+            }
         }
         self
     }
@@ -266,6 +281,8 @@ impl MockTransaction {
             MockTransaction::Legacy { gas_price, .. } => *gas_price,
             MockTransaction::Eip1559 { max_fee_per_gas, .. } => *max_fee_per_gas,
             MockTransaction::Eip4844 { max_fee_per_gas, .. } => *max_fee_per_gas,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => panic!("not implemented"),
         }
     }
 
@@ -351,6 +368,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { hash, .. } => hash,
             MockTransaction::Eip1559 { hash, .. } => hash,
             MockTransaction::Eip4844 { hash, .. } => hash,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(TxDeposit { source_hash, .. }) => source_hash,
         }
     }
 
@@ -359,6 +378,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { sender, .. } => *sender,
             MockTransaction::Eip1559 { sender, .. } => *sender,
             MockTransaction::Eip4844 { sender, .. } => *sender,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(TxDeposit { from, .. }) => *from,
         }
     }
 
@@ -367,7 +388,13 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { nonce, .. } => *nonce,
             MockTransaction::Eip1559 { nonce, .. } => *nonce,
             MockTransaction::Eip4844 { nonce, .. } => *nonce,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => 0u64,
         }
+    }
+
+    fn input(&self) -> &Bytes {
+        panic!("not implemented")
     }
 
     fn cost(&self) -> U256 {
@@ -381,6 +408,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Eip4844 { max_fee_per_gas, value, gas_limit, .. } => {
                 U256::from(*gas_limit) * U256::from(*max_fee_per_gas) + *value
             }
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => U256::ZERO,
         }
     }
 
@@ -393,6 +422,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { gas_price, .. } => *gas_price,
             MockTransaction::Eip1559 { max_fee_per_gas, .. } => *max_fee_per_gas,
             MockTransaction::Eip4844 { max_fee_per_gas, .. } => *max_fee_per_gas,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => 0u128,
         }
     }
 
@@ -405,6 +436,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Eip4844 { max_priority_fee_per_gas, .. } => {
                 Some(*max_priority_fee_per_gas)
             }
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => None,
         }
     }
 
@@ -428,6 +461,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { gas_price, .. } => *gas_price,
             MockTransaction::Eip1559 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
             MockTransaction::Eip4844 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => 0u128,
         }
     }
 
@@ -436,6 +471,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { to, .. } => to,
             MockTransaction::Eip1559 { to, .. } => to,
             MockTransaction::Eip4844 { to, .. } => to,
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(TxDeposit { to, .. }) => to,
         }
     }
 
@@ -448,6 +485,8 @@ impl PoolTransaction for MockTransaction {
             MockTransaction::Legacy { .. } => TxType::Legacy.into(),
             MockTransaction::Eip1559 { .. } => TxType::EIP1559.into(),
             MockTransaction::Eip4844 { .. } => TxType::EIP4844.into(),
+            #[cfg(feature = "optimism")]
+            MockTransaction::Deposit(_) => DEPOSIT_TX_TYPE_ID,
         }
     }
 
@@ -457,6 +496,11 @@ impl PoolTransaction for MockTransaction {
 
     fn chain_id(&self) -> Option<u64> {
         Some(1)
+    }
+
+    #[cfg(feature = "optimism")]
+    fn is_deposit(&self) -> bool {
+        matches!(self, MockTransaction::Deposit(_))
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use futures_util::{ready, Stream};
 use reth_primitives::{
-    Address, FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, Transaction,
+    Address, Bytes, FromRecoveredTransaction, IntoRecoveredTransaction, PeerId, Transaction,
     TransactionKind, TransactionSignedEcRecovered, TxHash, EIP1559_TX_TYPE_ID, EIP4844_TX_TYPE_ID,
     H256, U256,
 };
@@ -506,6 +506,9 @@ pub trait PoolTransaction:
     /// Returns the nonce for this transaction.
     fn nonce(&self) -> u64;
 
+    /// The transaction input data.
+    fn input(&self) -> &Bytes;
+
     /// Returns the cost that this transaction is allowed to consume:
     ///
     /// For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
@@ -562,6 +565,10 @@ pub trait PoolTransaction:
 
     /// Returns chain_id
     fn chain_id(&self) -> Option<u64>;
+
+    /// Returns whether or not the transaction is an Optimism Deposited transaction.
+    #[cfg(feature = "optimism")]
+    fn is_deposit(&self) -> bool;
 }
 
 /// The default [PoolTransaction] for the [Pool](crate::Pool).
@@ -614,6 +621,11 @@ impl PoolTransaction for PooledTransaction {
     /// Returns the nonce for this transaction.
     fn nonce(&self) -> u64 {
         self.transaction.nonce()
+    }
+
+    /// The transaction input data.
+    fn input(&self) -> &Bytes {
+        self.transaction.transaction.input()
     }
 
     /// Returns the cost that this transaction is allowed to consume:
@@ -697,6 +709,12 @@ impl PoolTransaction for PooledTransaction {
     /// Returns chain_id
     fn chain_id(&self) -> Option<u64> {
         self.transaction.chain_id()
+    }
+
+    /// Returns whether or not the transaction is an Optimism Deposited transaction.
+    #[cfg(feature = "optimism")]
+    fn is_deposit(&self) -> bool {
+        matches!(self.transaction.transaction, Transaction::Deposit(_))
     }
 }
 


### PR DESCRIPTION
**Description**

Contains all Changes for the Tx Pool Cost Updates.

Closes https://github.com/paradigmxyz/reth/issues/3751

- [x] Prevent deposit transactions from being added to transaction pool using the validation methods.
  <details>
  <summary>Follows op-geth's `validateTxBasics` function logic, screenshot in toggle.</summary>
  <img width="634" alt="Screenshot 2023-08-13 at 7 34 31 PM" src="https://github.com/anton-rs/op-reth/assets/21288394/cfcc55d5-90f1-4966-8a12-7df5a0e99305">
  </details>
- [x] Apply the L1 Cost function to tx in the tx pool.
  <details>
  <summary>Applies the l1 cost function to tx pool validation.</summary>
  <img width="808" alt="Screenshot 2023-08-14 at 5 42 04 PM" src="https://github.com/anton-rs/op-reth/assets/21288394/3ca7ecfd-4448-4faf-b6c3-c22a3d4331a2">
  </details>
❌ Transaction Journaling - this should not be needed
  <details>
  <summary>Adds transaction journaling.</summary>
  <img width="643" alt="Screenshot 2023-08-14 at 5 44 57 PM" src="https://github.com/anton-rs/op-reth/assets/21288394/ef8f4a13-76f7-4bce-97e7-5e9568519071">
  </details>