### PR TITLE
feat: Inclusive Default Feature Flags

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -95,7 +95,7 @@ jemallocator = { version = "0.5.0", optional = true }
 jemalloc-ctl = { version = "0.5.0", optional = true }
 
 [features]
-default = ["jemalloc"]
+default = ["jemalloc", "ethereum"]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]
 jemalloc-prof = ["jemalloc", "jemallocator?/profiling"]
 min-error-logs = ["tracing/release_max_level_error"]
@@ -116,6 +116,7 @@ optimism = [
   "reth-network/optimism",
   "reth-network-api/optimism"
 ]
+ethereum = []
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -205,6 +205,18 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
     pub async fn execute(mut self, ctx: CliContext) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
+        #[cfg(not(any(feature = "ethereum", feature = "optimism")))]
+        compile_error!(
+            "Either feature \"optimism\" or \"ethereum\" must be enabled for this crate."
+        );
+
+        // We cannot do this since runs with `--all-features` will error.
+        // See mutually exclusive features discussion here:
+        // https://github.com/rust-lang/cargo/issues/2980
+        //
+        // #[cfg(all(feature = "ethereum", feature = "optimism"))]
+        // compile_error!("Cannot use both \"optimism\" and \"ethereum\" feature flags.");
+
         // Raise the fd limit of the process.
         // Does not do anything on windows.
         raise_fd_limit();


### PR DESCRIPTION
**Description**

This adds a default `ethereum` feature flag to the bin crate and an associated [compile error](https://doc.rust-lang.org/std/macro.compile_error.html) to prevent compilation if **neither** `ethereum` nor `optimism` are specified as feature flags.

This is in reference to discussion [here](https://github.com/anton-rs/op-reth/pull/59/files#r1293454888)

Notice, we cannot perform a mutually exclusive feature flag check since any runs with `--all-features` will cause compilation to break.