### PR TITLE
feat: Add Optimism fields to `rpc-types`

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -26,8 +26,8 @@ use reth_primitives::{
         BEACON_NONCE, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS,
         ETHEREUM_BLOCK_GAS_LIMIT, RETH_CLIENT_VERSION, SLOT_DURATION,
     },
-    proofs, Block, BlockNumberOrTag, ChainSpec, Hardfork, Header, IntoRecoveredTransaction,
-    Receipt, SealedBlock, Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
+    proofs, Block, BlockNumberOrTag, ChainSpec, Header, IntoRecoveredTransaction, Receipt,
+    SealedBlock, Withdrawal, EMPTY_OMMER_ROOT, H256, U256,
 };
 use reth_provider::{BlockReaderIdExt, BlockSource, PostState, StateProviderFactory};
 use reth_revm::{

--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -1,6 +1,7 @@
 //! Optimism's [PayloadBuilder] implementation.
 
 use super::*;
+use reth_primitives::Hardfork;
 
 /// Constructs an Ethereum transaction payload from the transactions sent through the
 /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -203,13 +203,13 @@ impl proptest::arbitrary::Arbitrary for Receipt {
                         success in any::<bool>(),
                         cumulative_gas_used in any::<u64>(),
                         logs in proptest::collection::vec(proptest::arbitrary::any::<Log>(), 0..=20),
-                        deposit_nonce in any::<Option<u64>>()) -> Receipt
+                        _deposit_nonce in any::<Option<u64>>()) -> Receipt
             {
 
                 // Only reecipts for deposit transactions may contain a deposit nonce
                 #[cfg(feature = "optimism")]
                 let deposit_nonce = if tx_type == TxType::DEPOSIT {
-                    deposit_nonce
+                    _deposit_nonce
                 } else {
                     None
                 };

--- a/crates/rpc/rpc-types-compat/src/transaction/mod.rs
+++ b/crates/rpc/rpc-types-compat/src/transaction/mod.rs
@@ -123,5 +123,12 @@ fn fill(
         block_hash,
         block_number: block_number.map(U256::from),
         transaction_index,
+
+        #[cfg(feature = "optimism")]
+        source_hash: signed_tx.is_deposit().then_some(signed_tx.source_hash()),
+        #[cfg(feature = "optimism")]
+        mint: signed_tx.mint(),
+        #[cfg(feature = "optimism")]
+        is_system_tx: signed_tx.is_deposit().then_some(signed_tx.is_system_transaction()),
     }
 }

--- a/crates/rpc/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/mod.rs
@@ -63,6 +63,20 @@ pub struct Transaction {
     /// Some(1) for AccessList transaction, None for Legacy
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<U64>,
+
+    /// Hash that uniquely identifies the source of the deposit.
+    #[cfg(feature = "optimism")]
+    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<H256>,
+    /// The ETH value to mint on L2
+    #[cfg(feature = "optimism")]
+    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
+    pub mint: Option<u128>,
+    /// Field indicating whether the transaction is a system transaction, and therefore
+    /// exempt from the L2 gas limit.
+    #[cfg(feature = "optimism")]
+    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
+    pub is_system_tx: Option<bool>,
 }
 
 #[cfg(test)]
@@ -95,6 +109,12 @@ mod tests {
             transaction_type: Some(U64::from(20)),
             max_fee_per_gas: Some(U128::from(21)),
             max_priority_fee_per_gas: Some(U128::from(22)),
+            #[cfg(feature = "optimism")]
+            source_hash: None,
+            #[cfg(feature = "optimism")]
+            mint: None,
+            #[cfg(feature = "optimism")]
+            is_system_tx: None,
         };
         let serialized = serde_json::to_string(&transaction).unwrap();
         assert_eq!(
@@ -130,6 +150,12 @@ mod tests {
             transaction_type: Some(U64::from(20)),
             max_fee_per_gas: Some(U128::from(21)),
             max_priority_fee_per_gas: Some(U128::from(22)),
+            #[cfg(feature = "optimism")]
+            source_hash: None,
+            #[cfg(feature = "optimism")]
+            mint: None,
+            #[cfg(feature = "optimism")]
+            is_system_tx: None,
         };
         let serialized = serde_json::to_string(&transaction).unwrap();
         assert_eq!(

--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -43,4 +43,8 @@ pub struct TransactionReceipt {
     /// EIP-2718 Transaction type, Some(1) for AccessList transaction, None for Legacy
     #[serde(rename = "type")]
     pub transaction_type: U8,
+    /// Deposit nonce for deposit transactions post-regolith
+    #[cfg(feature = "optimism")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "depositNonce")]
+    pub deposit_nonce: Option<u64>,
 }

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -899,6 +899,8 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
         state_root: None,
         logs_bloom: receipt.bloom_slow(),
         status_code: if receipt.success { Some(U64::from(1)) } else { Some(U64::from(0)) },
+        #[cfg(feature = "optimism")]
+        deposit_nonce: receipt.deposit_nonce,
     };
 
     match tx.transaction.kind() {


### PR DESCRIPTION
## Overview

Adds OP fields to `rpc-types`' `Receipt` and `Transaction` 