### PR TITLE
fix(executor): Deposit Failure `CfgEnv` reset

### DIFF
--- a/crates/revm/src/optimism/executor.rs
+++ b/crates/revm/src/optimism/executor.rs
@@ -181,6 +181,11 @@ where
                             is_regolith,
                             BlockExecutionError::ProviderError
                         );
+                        // Reset all revm configuration flags for the next iteration.
+                        self.evm.env.cfg.disable_base_fee = false;
+                        self.evm.env.cfg.disable_block_gas_limit = false;
+                        self.evm.env.cfg.disable_balance_check = false;
+                        self.evm.env.cfg.disable_gas_refund = false;
                         continue
                     }
                     return Err(err)


### PR DESCRIPTION
## Overview

Fixes a bug where the evm's `CfgEnv` did not have its configuration reset after a deposit fails with an EVM failure. This caused a diff in the gas consumption around block 3.27M ([this tx](https://goerli.basescan.org/tx/0x25820f992f05cb0f7b510df078867f37c527dc4a0bb365ce56b3196f71d8ec2c)) on base goerli due to an `SSTORE` not receiving a gas refund.