### PR TITLE
perf(executor): pre-parse address constants

### DIFF
--- a/crates/payload/basic/src/optimism.rs
+++ b/crates/payload/basic/src/optimism.rs
@@ -232,7 +232,7 @@ where
                         &mut db,
                         &mut post_state,
                         parent_block.number + 1,
-                        executor::optimism::l1_cost_recipient(),
+                        *executor::optimism::L1_FEE_RECIPIENT,
                         l1_cost,
                     )?
                 }
@@ -240,7 +240,7 @@ where
                     &mut db,
                     &mut post_state,
                     parent_block.number + 1,
-                    executor::optimism::base_fee_recipient(),
+                    *executor::optimism::BASE_FEE_RECIPIENT,
                     U256::from(base_fee.saturating_mul(result.gas_used())),
                 )?;
             }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -23,6 +23,8 @@ revm.workspace = true
 # common
 tracing.workspace = true
 
+once_cell = { version = "1.17.0", optional = true }
+
 [dev-dependencies]
 reth-rlp.workspace = true
 once_cell = "1.17.0"
@@ -33,5 +35,6 @@ optimism = [
   "reth-revm-primitives/optimism",
   "reth-consensus-common/optimism",
   "reth-interfaces/optimism",
+  "once_cell"
 ]
 

--- a/crates/revm/src/optimism/executor.rs
+++ b/crates/revm/src/optimism/executor.rs
@@ -225,14 +225,14 @@ where
                     if let Some(l1_cost) = l1_cost {
                         self.increment_account_balance(
                             block.number,
-                            super::l1_cost_recipient(),
+                            *super::L1_FEE_RECIPIENT,
                             l1_cost,
                             &mut post_state,
                         )?
                     }
                     self.increment_account_balance(
                         block.number,
-                        super::base_fee_recipient(),
+                        *super::BASE_FEE_RECIPIENT,
                         U256::from(
                             block
                                 .base_fee_per_gas


### PR DESCRIPTION
## Description

Pre-parse the address constants used in hot functions during the execution & block building.

Addresses https://github.com/paradigmxyz/reth/pull/4377#discussion_r1307179990.