### PR TITLE
fix: Switch chain names to kebab casing

### DIFF
--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -30,7 +30,7 @@ pub fn chain_spec_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Er
         "sepolia" => SEPOLIA.clone(),
         "dev" => DEV.clone(),
         #[cfg(feature = "optimism")]
-        "base_goerli" => BASE_GOERLI.clone(),
+        "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base" => BASE_MAINNET.clone(),
         _ => {
@@ -49,7 +49,7 @@ pub fn genesis_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error
         "sepolia" => SEPOLIA.clone(),
         "dev" => DEV.clone(),
         #[cfg(feature = "optimism")]
-        "base_goerli" => BASE_GOERLI.clone(),
+        "base-goerli" => BASE_GOERLI.clone(),
         #[cfg(feature = "optimism")]
         "base" => BASE_MAINNET.clone(),
         _ => {
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn parse_chain_spec() {
-        for chain in ["mainnet", "sepolia", "goerli"] {
+        for chain in ["mainnet", "sepolia", "goerli", "base-goerli", "base"] {
             chain_spec_value_parser(chain).unwrap();
             genesis_value_parser(chain).unwrap();
         }

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -119,9 +119,18 @@ mod tests {
     use proptest::prelude::Rng;
     use secp256k1::rand::thread_rng;
 
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn pase_optimism_chain_spec() {
+        for chain in ["base-goerli", "base"] {
+            chain_spec_value_parser(chain).unwrap();
+            genesis_value_parser(chain).unwrap();
+        }
+    }
+
     #[test]
     fn parse_chain_spec() {
-        for chain in ["mainnet", "sepolia", "goerli", "base-goerli", "base"] {
+        for chain in ["mainnet", "sepolia", "goerli"] {
             chain_spec_value_parser(chain).unwrap();
             genesis_value_parser(chain).unwrap();
         }

--- a/bin/reth/src/args/utils.rs
+++ b/bin/reth/src/args/utils.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[cfg(feature = "optimism")]
     #[test]
-    fn pase_optimism_chain_spec() {
+    fn parse_optimism_chain_spec() {
         for chain in ["base-goerli", "base"] {
             chain_spec_value_parser(chain).unwrap();
             genesis_value_parser(chain).unwrap();


### PR DESCRIPTION
**Description**

Uses [kebab-case](https://en.wiktionary.org/wiki/kebab_case) for chain names instead of snake case.

Also adds `base-goerli` and `base` chain spec parsing tests to the args utils.