### PR TITLE
fix: Feature Flag Compiling Errors

### DIFF
--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -61,6 +61,11 @@ pub struct Cli<Ext: RethCliExt = ()> {
 impl<Ext: RethCliExt> Cli<Ext> {
     /// Execute the configured cli command.
     pub fn run(mut self) -> eyre::Result<()> {
+        #[cfg(not(any(feature = "ethereum", feature = "optimism")))]
+        compile_error!(
+            "Either feature \"optimism\" or \"ethereum\" must be enabled for this crate."
+        );
+
         // add network name to logs dir
         self.logs.log_directory = self.logs.log_directory.join(self.chain.chain.to_string());
 

--- a/bin/reth/src/node/mod.rs
+++ b/bin/reth/src/node/mod.rs
@@ -207,11 +207,6 @@ impl<Ext: RethCliExt> NodeCommand<Ext> {
     pub async fn execute(mut self, ctx: CliContext) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth {} starting", SHORT_VERSION);
 
-        #[cfg(not(any(feature = "ethereum", feature = "optimism")))]
-        compile_error!(
-            "Either feature \"optimism\" or \"ethereum\" must be enabled for this crate."
-        );
-
         // Raise the fd limit of the process.
         // Does not do anything on windows.
         raise_fd_limit();


### PR DESCRIPTION
**Description**

Moves the compile error to the reth cli runner entrypoint as opposed to `node` subcommand specific entrypoint.