### PR TITLE
fix: Remove Optimism Feat on U64 Serde Helper

### DIFF
--- a/crates/primitives/src/serde_helper/mod.rs
+++ b/crates/primitives/src/serde_helper/mod.rs
@@ -33,7 +33,6 @@ pub mod u64_hex {
 }
 
 /// serde functions for handling `Option<u64>` as [U64](crate::U64)
-#[cfg(feature = "optimism")]
 pub mod option_u64_hex {
     use crate::U64;
     use serde::{Deserialize, Deserializer};


### PR DESCRIPTION
**Description**

Addresses upstream review comment @ https://github.com/paradigmxyz/reth/pull/4377#discussion_r1307174072 to remove the optimism feature flag above the U64 serde helper.