### PR TITLE
fix: Comment on the Compat Tx Type Buffer Reading 

### DIFF
--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -552,6 +552,11 @@ impl Compact for Transaction {
                 (Transaction::Eip1559(tx), buf)
             }
             3 => {
+                // An identifier of 3 indicates that the transaction type did not fit into
+                // the backwards compatible 2 bit identifier, their transaction types are
+                // larger than 2 bits (eg. 4844 and Deposit Transactions). In this case,
+                // we need to read the concrete transaction type from the buffer by
+                // reading the full 8 bits (single byte) and match on this transaction type.
                 let identifier = buf.get_u8() as usize;
                 match identifier {
                     3 => {


### PR DESCRIPTION
**Description**

Adds a comment as to why an identifier of `3` means we must read a full byte from the buffer in order to match on transaction types that are larger than two bits fitting inside the identifier.