### PR TITLE
fix: Redundant Serde Camel Case Renames in RPC Transaction Receipt

### DIFF
--- a/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc/rpc-types/src/eth/transaction/receipt.rs
@@ -45,22 +45,22 @@ pub struct TransactionReceipt {
     pub transaction_type: U8,
     /// Deposit nonce for deposit transactions post-regolith
     #[cfg(feature = "optimism")]
-    #[serde(skip_serializing_if = "Option::is_none", rename = "depositNonce")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deposit_nonce: Option<U64>,
     /// L1 fee for the transaction
     #[cfg(feature = "optimism")]
-    #[serde(skip_serializing_if = "Option::is_none", rename = "l1Fee")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub l1_fee: Option<U256>,
     /// L1 fee scalar for the transaction
     #[cfg(feature = "optimism")]
-    #[serde(skip_serializing_if = "Option::is_none", rename = "l1FeeScalar")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub l1_fee_scalar: Option<U256>,
     /// L1 gas price for the transaction
     #[cfg(feature = "optimism")]
-    #[serde(skip_serializing_if = "Option::is_none", rename = "l1GasPrice")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub l1_gas_price: Option<U256>,
     /// L1 gas used for the transaction
     #[cfg(feature = "optimism")]
-    #[serde(skip_serializing_if = "Option::is_none", rename = "l1GasUsed")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub l1_gas_used: Option<U256>,
 }


### PR DESCRIPTION
**Description**

Fixes the suggestion in https://github.com/paradigmxyz/reth/pull/4377#discussion_r1307180917 to remove the optimism feature field serde renames here since they are redundant and handled by the top-level serde camel case rename.