### PR TITLE
Start the move to mutually exclusive features

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,13 +64,16 @@ jobs:
     name: check
     runs-on:
       group: Reth
+    strategy:
+      matrix:
+        network: ["ethereum", "optimism"]
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check if benchmarks build
-        run: cargo check --workspace --benches --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
+        run: cargo check --workspace --benches --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
 
   bench-success:
     if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -70,7 +70,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check if benchmarks build
-        run: cargo check --workspace --benches --all-features
+        run: cargo check --workspace --benches --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
 
   bench-success:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         with:
-          args: --all --all-features -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
+          args: --all --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
           token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-lint:
@@ -49,7 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check if documentation builds
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --all-features --document-private-items
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --document-private-items
 
   grafana-lint:
     name: grafana lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
   lint:
     name: code lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        network: ["ethereum", "optimism"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -37,19 +40,22 @@ jobs:
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         with:
-          args: --all --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
+          args: --all --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" -- -A clippy::incorrect_clone_impl_on_copy_type -A clippy::arc_with_non_send_sync
           token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-lint:
     name: doc lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        network: ["ethereum", "optimism"]
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check if documentation builds
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --document-private-items
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --document-private-items
 
   grafana-lint:
     name: grafana lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2]
+        network: ["ethereum", "optimism"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -52,7 +53,7 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
+            --locked --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
             --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(test)'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --all-features --workspace --exclude examples --exclude ef-tests \
+            --locked --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
+            --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(test)'
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo nextest run --locked --workspace --all-features \
+          cargo nextest run --locked --workspace \
+            --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
@@ -76,7 +77,7 @@ jobs:
         run: cargo install cargo-udeps --locked
 
       - name: Check for unused dependencies
-        run: cargo +nightly udeps --all-features --all-targets
+        run: cargo +nightly udeps --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --all-targets
 
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2, 3]
+        network: ["ethereum", "optimism"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -51,7 +52,7 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run --locked --workspace \
-            --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
+            --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
@@ -67,6 +68,9 @@ jobs:
   unused-deps:
     runs-on: ubuntu-20.04
     name: unused dependencies
+    strategy:
+      matrix:
+        network: ["ethereum", "optimism"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -77,7 +81,7 @@ jobs:
         run: cargo install cargo-udeps --locked
 
       - name: Check for unused dependencies
-        run: cargo +nightly udeps --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --all-targets
+        run: cargo +nightly udeps --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" --all-targets
 
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --all-features --workspace --exclude examples --exclude ef-tests  \
+            --locked --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
+            --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
 
@@ -94,7 +95,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run doctests
-        run: cargo test --doc --all --all-features
+        run: cargo test --doc --all --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
 
   unit-success:
     if: always()

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2]
+        network: ["ethereum", "optimism"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -40,7 +41,7 @@ jobs:
       - name: Run tests
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info \
-            --locked --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
+            --locked --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs" \
             --workspace --exclude examples --exclude ef-tests \
             --partition hash:${{ matrix.partition }}/${{ strategy.job-total }} \
             -E 'kind(lib)' -E 'kind(bin)' -E 'kind(proc-macro)'
@@ -89,13 +90,16 @@ jobs:
     name: rustdoc
     runs-on:
       group: Reth
+    strategy:
+      matrix:
+        network: ["ethereum", "optimism"]
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run doctests
-        run: cargo test --doc --all --features "jemalloc-prof,ethereum,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
+        run: cargo test --doc --all --features "jemalloc-prof,${{ matrix.network }},min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs"
 
   unit-success:
     if: always()

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -97,7 +97,7 @@ jemallocator = { version = "0.5.0", optional = true }
 jemalloc-ctl = { version = "0.5.0", optional = true }
 
 [features]
-default = ["jemalloc", "ethereum"]
+default = ["jemalloc"]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl"]
 jemalloc-prof = ["jemalloc", "jemallocator?/profiling"]
 min-error-logs = ["tracing/release_max_level_error"]

--- a/bin/reth/src/cli/ext.rs
+++ b/bin/reth/src/cli/ext.rs
@@ -96,6 +96,7 @@ pub trait RethNodeCommandConfig: fmt::Debug {
 
         // The default payload builder is implemented on the unit type.
         #[cfg(not(feature = "optimism"))]
+        #[allow(clippy::let_unit_value)]
         let payload_builder = ();
 
         // Optimism's payload builder is impelmented on the OptimismPayloadBuilder type.

--- a/bin/reth/src/cli/mod.rs
+++ b/bin/reth/src/cli/mod.rs
@@ -60,9 +60,9 @@ pub struct Cli<Ext: RethCliExt = ()> {
 impl<Ext: RethCliExt> Cli<Ext> {
     /// Execute the configured cli command.
     pub fn run(mut self) -> eyre::Result<()> {
-        #[cfg(not(any(feature = "ethereum", feature = "optimism")))]
+        #[cfg(all(feature = "ethereum", feature = "optimism"))]
         compile_error!(
-            "Either feature \"optimism\" or \"ethereum\" must be enabled for this crate."
+            "Only one of the \"ethereum\" or \"optimism\" features can be enabled for this crate."
         );
 
         // add network name to logs dir

--- a/crates/rpc/rpc/src/eth/api/transactions.rs
+++ b/crates/rpc/rpc/src/eth/api/transactions.rs
@@ -958,7 +958,14 @@ pub(crate) fn build_transaction_receipt_with_block_receipts(
         status_code: if receipt.success { Some(U64::from(1)) } else { Some(U64::from(0)) },
         #[cfg(feature = "optimism")]
         deposit_nonce: receipt.deposit_nonce.map(U64::from),
-        ..Default::default()
+        #[cfg(feature = "optimism")]
+        l1_fee: None,
+        #[cfg(feature = "optimism")]
+        l1_gas_used: None,
+        #[cfg(feature = "optimism")]
+        l1_fee_scalar: None,
+        #[cfg(feature = "optimism")]
+        l1_gas_price: None,
     };
 
     #[cfg(feature = "optimism")]


### PR DESCRIPTION
## Overview

Moves to mutually exclusive `optimism` and `ethereum` features.

### TODO
- [x] Update existing workflows to not include the `optimism` feature flag.
- [x] Error binary compilation if both the `ethereum` and `optimism` feature flags are enabled.
- [x] Create a matrix in the workflow that swaps on the network feature so that both `ethereum` and `optimism` features can be tested in CI.