### PR TITLE
fix: Base Mainnet Chain Accessor

### DIFF
--- a/crates/primitives/src/chain/mod.rs
+++ b/crates/primitives/src/chain/mod.rs
@@ -68,9 +68,7 @@ impl Chain {
     /// Returns the base mainnet chain.
     #[cfg(feature = "optimism")]
     pub const fn base_mainnet() -> Self {
-        // TODO: add to ethers-core
-        //Chain::Named(ethers_core::types::Chain::Base)
-        Chain::Id(8453)
+        Chain::Named(ethers_core::types::Chain::Base)
     }
 
     /// Returns the dev chain.


### PR DESCRIPTION
**Description**

Updates base mainnet to use named ethers chain over hardcoded chain id.