### PR TITLE
chore: add deletion tests for op proofs storage

### DIFF
--- a/crates/optimism/trie/tests/lib.rs
+++ b/crates/optimism/trie/tests/lib.rs
@@ -1596,8 +1596,7 @@ async fn test_replace_updates_applies_all_updates<S: OpProofsStorage>(
     Ok(())
 }
 
-
-/// Test that pure deletions (nodes only in removed_nodes) are properly stored
+/// Test that pure deletions (nodes only in `removed_nodes`) are properly stored
 ///
 /// This test verifies that when a node appears only in `removed_nodes` (not in updates),
 /// it is properly stored as a deletion and subsequent queries return None for that path.


### PR DESCRIPTION
Based on #229 

Adds tests to ensure that storing TrieUpdates that include deletions actually deletes the nodes at that block height, and that updates take precedence over deletions (same as `write_trie_updates` in Reth).

Closes #238