### PR TITLE
chore(optimism): remove unused dev-dependencies from reth-optimism-trie

### DIFF
--- a/crates/optimism/trie/Cargo.toml
+++ b/crates/optimism/trie/Cargo.toml
@@ -55,14 +55,10 @@ reth-db = { workspace = true, features = ["test-utils"] }
 reth-db-api = { workspace = true, features = ["test-utils"] }
 reth-trie = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-node-api.workspace = true
 alloy-consensus.workspace = true
 alloy-genesis.workspace = true
 reth-chainspec.workspace = true
-reth-db-common.workspace = true
 reth-ethereum-primitives.workspace = true
-reth-evm-ethereum.workspace = true
-reth-testing-utils.workspace = true
 secp256k1.workspace = true
 
 [features]


### PR DESCRIPTION
Closes #283

Removes unused dev-dependencies (`reth-db-common`, `reth-evm-ethereum`, `reth-node-api`, `reth-testing-utils`) from `reth-optimism-trie` that were causing the `udeps` CI check to fail. These dependencies are not used anywhere in the codebase, so removing them is safe and reduces build times.