### PR TITLE
fix(docs): Fixes docs of `reth_optimism_trie::cursor_factory`

### DIFF
--- a/crates/optimism/trie/src/cursor_factory.rs
+++ b/crates/optimism/trie/src/cursor_factory.rs
@@ -1,4 +1,4 @@
-//! Provides proof operation implementations for [`OpProofsStore`].
+//! Implements [`TrieCursorFactory`] and [`HashedCursorFactory`] for [`OpProofsStore`] types.
 
 use crate::{
     OpProofsHashedAccountCursor, OpProofsHashedStorageCursor, OpProofsStorage, OpProofsStore,


### PR DESCRIPTION
Fixes module docs of `reth_optimism_trie::cursor_factory`, which weren't updated on moving the code out of the proofs module