### PR TITLE
fix(deps): Fix unused dependencies check

### DIFF
--- a/crates/optimism/trie/src/lib.rs
+++ b/crates/optimism/trie/src/lib.rs
@@ -10,7 +10,7 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(any(test, feature = "metrics")), warn(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod api;
 pub use api::{

--- a/crates/optimism/trie/tests/lib.rs
+++ b/crates/optimism/trie/tests/lib.rs
@@ -1,5 +1,7 @@
 //! Common test suite for `OpProofsStorage` implementations.
 
+#![cfg_attr(feature = "metrics", expect(unused_crate_dependencies))]
+
 use alloy_primitives::{map::HashMap, B256, U256};
 use reth_optimism_trie::{
     BlockStateDiff, InMemoryProofsStorage, OpProofsHashedCursorRO, OpProofsStorageError,


### PR DESCRIPTION
Closes https://github.com/op-rs/op-reth/issues/283

Disable `unused_crate_dependencies` warning when metrics feature is enabled. Live collector tests are disabled when metrics flag is enabled. This can be changed in the future, the tests don't necessarily need to be disabled.