### PR TITLE
fix(grafana): OP-reth dashboard title

### DIFF
--- a/etc/grafana/dashboards/op-reth.json
+++ b/etc/grafana/dashboards/op-reth.json
@@ -398,7 +398,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "OP-Reth - RPC Metrics",
+  "title": "OP-Reth",
   "uid": "8438c957-55f5-44df-869d-a9a30a3c9a97",
   "version": 2,
   "weekStart": ""


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/199

Strips "RPC Metrics" from op-reth dashboard title. Dashboard serves as general execution layer metrics unique to op-stack.