### PR TITLE
chore(trie): Rename metrics scope

### DIFF
--- a/crates/optimism/trie/src/metrics.rs
+++ b/crates/optimism/trie/src/metrics.rs
@@ -167,7 +167,7 @@ impl Default for StorageMetrics {
 
 /// Metrics for individual storage operations.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "external_proofs.storage.operation")]
+#[metrics(scope = "optimism_trie.storage.operation")]
 struct OperationMetrics {
     /// Duration of storage operations in seconds
     duration_seconds: Histogram,
@@ -198,7 +198,7 @@ impl OperationMetrics {
 
 /// High-level block processing metrics.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "external_proofs.block")]
+#[metrics(scope = "optimism_trie.block")]
 pub struct BlockMetrics {
     /// Total time to process a block (end-to-end) in seconds
     pub total_duration_seconds: Histogram,


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/321

Renames scope for `BlockMetrics` and `OperationMetrics` from `external_proofs` to `optimism_trie`