### PR TITLE
feat: integrate metrics into live sync process

### DIFF
--- a/crates/optimism/trie/src/db/store.rs
+++ b/crates/optimism/trie/src/db/store.rs
@@ -1,5 +1,6 @@
 use super::{BlockNumberHash, ProofWindow, ProofWindowKey};
 use crate::{
+    api::WriteCounts,
     db::{
         cursor::Dup,
         models::{
@@ -81,7 +82,7 @@ impl MdbxProofsStorage {
         tx: &<DatabaseEnv as Database>::TXMut,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<()> {
+    ) -> OpProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
         // TODO: refactor the code - remove sorting out of tx
 
@@ -134,6 +135,8 @@ impl MdbxProofsStorage {
         let mut hashed_account_keys = Vec::<B256>::with_capacity(hashed_account_len);
         let mut hashed_storage_keys = Vec::<HashedStorageKey>::with_capacity(hashed_storage_len);
 
+        let mut write_counts = WriteCounts::default();
+
         let mut account_trie_cursor = tx.new_cursor::<AccountTrieHistory>()?;
         for (path, node) in sorted_account_nodes {
             let key: StoredNibbles = path.into();
@@ -141,6 +144,7 @@ impl MdbxProofsStorage {
             account_trie_cursor.append_dup(key.clone(), vv)?;
 
             account_trie_keys.push(key);
+            write_counts.account_trie_updates_written_total += 1;
         }
 
         let mut storage_trie_cursor = tx.new_cursor::<StorageTrieHistory>()?;
@@ -156,6 +160,7 @@ impl MdbxProofsStorage {
                     let del = VersionedValue { block_number, value: MaybeDeleted(None) };
                     storage_trie_cursor
                         .append_dup(StorageTrieKey::new(hashed_address, path.into()), del)?;
+                    write_counts.storage_trie_updates_written_total += 1;
                 }
                 // Skip any further processing for this hashed_address
                 continue;
@@ -166,6 +171,7 @@ impl MdbxProofsStorage {
                 storage_trie_cursor.append_dup(key.clone(), vv)?;
 
                 storage_trie_keys.push(key);
+                write_counts.storage_trie_updates_written_total += 1;
             }
         }
 
@@ -175,6 +181,7 @@ impl MdbxProofsStorage {
             account_cursor.append_dup(hashed_address, vv)?;
 
             hashed_account_keys.push(hashed_address);
+            write_counts.hashed_accounts_written_total += 1;
         }
 
         let mut storage_cursor = tx.new_cursor::<HashedStorageHistory>()?;
@@ -189,6 +196,7 @@ impl MdbxProofsStorage {
                     // Mark deleted at current block
                     let del = VersionedValue { block_number, value: MaybeDeleted(None) };
                     storage_cursor.append_dup(HashedStorageKey::new(*hashed_address, key), del)?;
+                    write_counts.hashed_storages_written_total += 1;
                 }
                 // Skip any further processing for this hashed_address
                 continue;
@@ -203,6 +211,7 @@ impl MdbxProofsStorage {
                 storage_cursor.append_dup(key.clone(), vv)?;
 
                 hashed_storage_keys.push(key);
+                write_counts.hashed_storages_written_total += 1;
             }
         }
 
@@ -224,7 +233,7 @@ impl MdbxProofsStorage {
             ProofWindowKey::LatestBlock,
             &BlockNumberHash::new(block_number, block_ref.block.hash),
         )?;
-        Ok(())
+        Ok(write_counts)
     }
 }
 
@@ -406,11 +415,8 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<()> {
-        self.env.update(|tx| {
-            self.store_trie_updates_inner(tx, block_ref, block_state_diff)?;
-            Ok(())
-        })?
+    ) -> OpProofsStorageResult<WriteCounts> {
+        self.env.update(|tx| self.store_trie_updates_inner(tx, block_ref, block_state_diff))?
     }
 
     async fn fetch_trie_updates(&self, block_number: u64) -> OpProofsStorageResult<BlockStateDiff> {


### PR DESCRIPTION
Fixes #246

- Return `UpdateResult` from `store_trie_updates` with counts of items stored.
- Log counts and latencies for live collector