### PR TITLE
feat(grafana): add transaction pool metrics panel

### DIFF
--- a/etc/grafana/dashboards/op-reth.json
+++ b/etc/grafana/dashboards/op-reth.json
@@ -463,7 +463,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(reth_transaction_pool_removed_tx_conditional{instance=~\"$instance\"}[5m])",
+          "expr": "rate(reth_transaction_pool_removed_tx_conditional{instance=~\"$instance\"}[$__rate_interval])",
           "legendFormat": "Removed transactions",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Closes #320

Adds Transaction Pool row with `removed_tx_conditional` metric panels. Includes both rate (primary) and total count (bonus) views for better monitoring.

<img width="2240" height="898" alt="image" src="https://github.com/user-attachments/assets/fd6f54f9-00ff-4354-a0d4-28df9835075e" />
