### PR TITLE
fix: add custom TrieType to separate metrics for op proofs storage

### DIFF
--- a/crates/optimism/trie/src/proof.rs
+++ b/crates/optimism/trie/src/proof.rs
@@ -346,7 +346,7 @@ where
             ),
             address,
             prefix_set,
-            TrieRootMetrics::new(TrieType::Storage),
+            TrieRootMetrics::new(TrieType::Custom("op_historical_proofs_storage")),
         )
         .root()
     }

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -726,6 +726,8 @@ pub enum TrieType {
     State,
     /// Storage trie type.
     Storage,
+    /// Custom trie type. Can be used in ExEx.
+    Custom(&'static str),
 }
 
 impl TrieType {
@@ -734,6 +736,7 @@ impl TrieType {
         match self {
             Self::State => "state",
             Self::Storage => "storage",
+            Self::Custom(s) => s,
         }
     }
 }


### PR DESCRIPTION
Closes #321 