### PR TITLE
fix: update metric on startup

### DIFF
--- a/crates/optimism/exex/Cargo.toml
+++ b/crates/optimism/exex/Cargo.toml
@@ -21,7 +21,7 @@ reth-provider.workspace = true
 
 # op-reth
 # proofs exex handles `TrieUpdates` in notifications
-reth-optimism-trie = { workspace = true, features = ["serde-bincode-compat"] }
+reth-optimism-trie = { workspace = true, features = ["serde-bincode-compat", "metrics"] }
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/optimism/exex/src/lib.rs
+++ b/crates/optimism/exex/src/lib.rs
@@ -109,7 +109,7 @@ where
         };
 
         // Need to update the earliest block metric on startup as this is not called frequently and
-        // can show outdated info.
+        // can show outdated info. When metrics are disabled, this is a no-op.
         self.storage.metrics().block_metrics().earliest_number.set(earliest_block_number as f64);
 
         let collector = LiveTrieCollector::new(


### PR DESCRIPTION
Closes #416 

Issue:

The issue was that CLI command `initialize-op-proofs` set the earliest block number but when the node starts, the metrics initialized are at default values. All other metrics get called soon after the start but not the earliest block number.

Solution:

Set the metric on startup, if available.