### PR TITLE
chore(ci): Recover codecov file from original main

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,50 +19,8 @@ component_management:
         - crates/config/**
         - crates/metrics/**
         - crates/tracing/**
-    - component_id: blockchain_tree
-      name: blockchain tree
+    - component_id: op-historical-proof
+      name: op historical proof
       paths:
-        - crates/blockchain-tree/**
-    - component_id: staged_sync
-      name: pipeline
-      paths:
-        - crates/stages/**
-    - component_id: storage
-      name: storage (db)
-      paths:
-        - crates/storage/**
-    - component_id: trie
-      name: trie
-      paths:
-        - crates/trie/**
-    - component_id: txpool
-      name: txpool
-      paths:
-        - crates/transaction-pool/**
-    - component_id: networking
-      name: networking
-      paths:
-        - crates/net/**
-    - component_id: rpc
-      name: rpc
-      paths:
-        - crates/rpc/**
-    - component_id: consensus
-      name: consensus
-      paths:
-        - crates/consensus/**
-    - component_id: revm
-      name: revm
-      paths:
-        - crates/revm/**
-    - component_id: builder
-      name: payload builder
-      paths:
-        - crates/payload/**
-    - component_id: primitives
-      name: primitives
-      paths:
-        - crates/primitives/**
-        - crates/tasks/**
-        - crates/rlp/**
-        - crates/interfaces/**
+        - crates/optimism/exex/**
+        - crates/optimism/trie/**


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/406
Based on https://github.com/op-rs/op-reth/pull/415

Checks out codecov config from archived main branch (from 2 years ago)