### PR TITLE
chore(ci): revert changes to runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,0 @@
-self-hosted-runner:
-  labels:
-    - depot-ubuntu-latest
-    - depot-ubuntu-latest-2
-    - depot-ubuntu-latest-4
-    - depot-ubuntu-latest-8
-    - depot-ubuntu-latest-16

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ env:
 name: bench
 jobs:
   codspeed:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout

--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -17,7 +17,7 @@ env:
 name: compact-codec
 jobs:
   compact-codec:
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         bin:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     name: e2e-testsuite
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 90

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -24,7 +24,7 @@ jobs:
   prepare-hive:
     if: github.repository == 'op-rs/op-reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Checkout hive tests
@@ -178,7 +178,7 @@ jobs:
       - prepare-reth
       - prepare-hive
     name: run ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
@@ -245,7 +245,7 @@ jobs:
   notify-on-error:
     needs: test
     if: failure()
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     name: test / ${{ matrix.network }}
     if: github.event_name != 'schedule'
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
     strategy:

--- a/.github/workflows/kurtosis-op.yml
+++ b/.github/workflows/kurtosis-op.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
     name: run kurtosis
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     needs:
       - prepare-reth
     steps:
@@ -85,7 +85,7 @@ jobs:
   notify-on-error:
     needs: test
     if: failure()
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
     name: run kurtosis
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     needs:
       - prepare-reth
     steps:
@@ -58,7 +58,7 @@ jobs:
   notify-on-error:
     needs: test
     if: failure()
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   clippy-binaries:
     name: clippy binaries / ${{ matrix.type }}
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   wasm:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +79,7 @@ jobs:
           .github/assets/check_wasm.sh
 
   riscv:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -98,7 +98,7 @@ jobs:
 
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -117,7 +117,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -140,7 +140,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -158,7 +158,7 @@ jobs:
 
   fmt:
     name: fmt
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -172,7 +172,7 @@ jobs:
 
   udeps:
     name: udeps
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -187,7 +187,7 @@ jobs:
 
   book:
     name: book
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -246,7 +246,7 @@ jobs:
   # Checks that selected crates can compile with power set of features
   features:
     name: features (${{ matrix.partition }}/${{ matrix.total_partitions }})
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         partition: [1, 2]
@@ -274,7 +274,7 @@ jobs:
 
   # Check crates correctly propagate features
   feature-propagation:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/prepare-reth.yml
+++ b/.github/workflows/prepare-reth.yml
@@ -26,7 +26,7 @@ jobs:
   prepare-reth:
     if: github.repository == 'op-rs/op-reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: mkdir artifacts

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,7 +23,7 @@ jobs:
     name: stage-run-test
     # Only run stage commands test in merge groups
     if: github.event_name == 'merge_group'
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sync:
     name: sync (${{ matrix.chain.bin }})
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sync:
     name: sync (${{ matrix.chain.bin }})
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: test / ${{ matrix.type }} (${{ matrix.partition }}/${{ matrix.total_partitions }})
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
     strategy:
@@ -66,7 +66,7 @@ jobs:
 
   state:
     name: Ethereum state tests
-    runs-on: depot-ubuntu-latest-4
+    runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -101,7 +101,7 @@ jobs:
 
   doc:
     name: doc tests
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 30

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   check-reth:
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: cargo check --target x86_64-pc-windows-gnu
 
   check-op-reth:
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Reverts changes to CI runners which were mistakenly pulled from upstream as part of https://github.com/op-rs/op-reth/issues/473