### PR TITLE
fix(book): Add missing docs from upstream main

### DIFF
--- a/docs/vocs/docs/pages/cli/op-reth/initialize-op-proofs.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/initialize-op-proofs.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/prune-op-proofs.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune-op-proofs.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/unwind-op-proofs.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/unwind-op-proofs.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/529

Fix conflicts pulled from upstream: add missing flag `--datadir.rocks-db` to proofs CLI tools