### PR TITLE
fix(trie): Fix broken `Debug` impl unit test

### DIFF
--- a/crates/optimism/trie/src/provider.rs
+++ b/crates/optimism/trie/src/provider.rs
@@ -225,7 +225,7 @@ mod tests {
 
         assert_eq!(
             format!("{:?}", provider),
-            "OpProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None } } }, block_number: 42 }"
+            "OpProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, address_mappings: {}, trie_updates: {}, post_states: {}, earliest_block: None } } }, block_number: 42 }"
         );
     }
 }


### PR DESCRIPTION
Fix broken unit test for verifying `Debug` impl, add missing map `address_mappings` to expected test output, introduced in  https://github.com/op-rs/op-reth/pull/512