### PR TITLE
chore(trie): return `OpProofsStorageError` from `unwind_history`

### DIFF
--- a/crates/optimism/trie/src/live.rs
+++ b/crates/optimism/trie/src/live.rs
@@ -224,8 +224,7 @@ where
 
     /// Remove account, storage and trie updates from historical storage for all blocks from
     /// the specified block (inclusive).
-    pub async fn unwind_history(&self, to: BlockWithParent) -> eyre::Result<()> {
-        self.storage.unwind_history(to).await?;
-        Ok(())
+    pub async fn unwind_history(&self, to: BlockWithParent) -> Result<(), OpProofsStorageError> {
+        self.storage.unwind_history(to).await
     }
 }


### PR DESCRIPTION
Cherry picks commit from https://github.com/op-rs/op-reth/pull/540