### PR TITLE
chore: remove stale RUSTSEC-2025-0137 advisory from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,8 +8,8 @@ ignore = [
     "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
-    "RUSTSEC-2025-0137",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, used by reth-nippy-jar
+    "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Closes #575