### PR TITLE
chore: added rpc to codecov `op-historical-proof` component

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,4 +23,6 @@ component_management:
       name: op historical proof
       paths:
         - crates/optimism/exex/**
+        - crates/optimism/rpc/src/debug.rs
+        - crates/optimism/rpc/src/eth/proofs.rs
         - crates/optimism/trie/**


### PR DESCRIPTION
Closes #503 