### PR TITLE
feat(flashblocks): add canonical block reconciliation to clear stale pending state

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -24,7 +24,7 @@ mod sequence;
 pub use sequence::{FlashBlockCompleteSequence, FlashBlockPendingSequence};
 
 mod service;
-pub use service::{FlashBlockBuildInfo, FlashBlockService};
+pub use service::{CanonicalBlockNotification, FlashBlockBuildInfo, FlashBlockService};
 
 mod worker;
 


### PR DESCRIPTION
Stacked on top of https://github.com/paradigmxyz/reth/pull/21081, will rebase once that merges.

## Summary

  Wire up the validation module to handle canonical block notifications, enabling the service to detect reorgs and clear stale pending state.

  Part of the [speculative flashblock building design](https://www.notion.so/oplabs/Flashblocks-Upstreaming-node-reth-features-2e8f153ee162805eaaa5f067fe3440a3?source=copy_link). Builds on [PR 1](https://github.com/paradigmxyz/reth/pull/21081).

  ## Motivation

  When the canonical chain advances or diverges from pending flashblock state, the service needs to reconcile. Without this, stale pending state persists until eventually overwritten, and there's no explicit signal to downstream consumers that a reorg occurred.

  ## Changes

  **`cache.rs`**
  - Add `earliest_block_number()` and `latest_block_number()` to `SequenceManager`
  - Add `get_transaction_hashes_for_block()` for reorg detection
  - Add `process_canonical_block()` that uses `ReorgDetector` and `CanonicalBlockReconciler` to determine and apply reconciliation strategy
  - Add `clear_all()` helper

  **`service.rs`**
  - Add `CanonicalBlockNotification` type with block number and transaction hashes
  - Add `canonical_block_rx` receiver field and `with_canonical_block_rx()` builder method
  - Add `max_depth` configuration with `with_max_depth()` builder method (default: 64)
  - Handle canonical block notifications in the main loop, calling `process_canonical_block()`
  - Add `reorg_count` metric

  ## Testing

  Unit tests for:
  - `process_canonical_block()` with each reconciliation strategy
  - `earliest_block_number()` / `latest_block_number()` tracking across pending and cached sequences