### PR TITLE
feat(flashblocks): add transaction caching to skip re-execution of unchanged transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9769,6 +9769,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "brotli",
  "derive_more",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -29,8 +29,9 @@ reth-metrics.workspace = true
 
 # alloy
 alloy-eips = { workspace = true, features = ["serde"] }
-alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-primitives = { workspace = true, features = ["serde", "map-foldhash"] }
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
 
 # op-alloy

--- a/crates/optimism/flashblocks/docs/client-side-upstream-scope.md
+++ b/crates/optimism/flashblocks/docs/client-side-upstream-scope.md
@@ -1,0 +1,317 @@
+# Client-Side Flashblocks Upstream Scope
+
+**Authors:** Upstreaming from node-reth
+**Status:** Planning
+**Date:** January 2026
+
+## Executive Summary
+
+This document scopes the work required to upstream the client-side flashblocks functionality from node-reth to reth. This enables any OP Stack follower node to receive flashblocks and serve flashblock-aware RPC endpoints.
+
+## Current State
+
+### reth (upstream) - Builder Side Only
+```
+crates/optimism/flashblocks/
+├── service.rs          # FlashBlockService (builds blocks)
+├── worker.rs           # Block execution
+├── cache.rs            # Sequence management
+├── pending_state.rs    # Speculative building state
+├── validation.rs       # Sequence validation, reorg detection
+├── ws/                 # WebSocket stream for receiving
+└── ...
+```
+
+### node-reth - Full Client Side
+```
+crates/client/flashblocks/
+├── state.rs            # FlashblocksState (coordinator)
+├── processor.rs        # StateProcessor (executes flashblocks)
+├── pending_blocks.rs   # PendingBlocks (RPC-queryable state)
+├── state_builder.rs    # PendingStateBuilder (tx execution)
+├── subscription.rs     # WebSocket subscriber with reconnection
+├── validation.rs       # Same as reth (already upstreamed)
+├── traits.rs           # FlashblocksAPI, PendingBlocksAPI
+├── extension.rs        # Node builder integration
+├── rpc/
+│   ├── eth.rs          # EthApiExt (flashblock-aware eth_*)
+│   └── pubsub.rs       # EthPubSub (flashblock subscriptions)
+└── ...
+```
+
+## Proposed Architecture
+
+### Module Structure
+```
+crates/optimism/flashblocks/
+├── src/
+│   ├── lib.rs
+│   │
+│   │   # Existing (builder-side)
+│   ├── service.rs
+│   ├── worker.rs
+│   ├── cache.rs
+│   ├── pending_state.rs
+│   ├── validation.rs
+│   ├── ws/
+│   │
+│   │   # New (client-side)
+│   ├── client/
+│   │   ├── mod.rs
+│   │   ├── state.rs            # FlashblocksClientState
+│   │   ├── processor.rs        # ClientStateProcessor
+│   │   ├── pending_blocks.rs   # ClientPendingBlocks
+│   │   └── state_builder.rs    # ClientStateBuilder
+│   │
+│   └── rpc/                    # New (optional feature)
+│       ├── mod.rs
+│       ├── eth_ext.rs          # EthApiFlashblocksExt
+│       ├── pubsub.rs           # FlashblocksPubSub
+│       └── types.rs            # Subscription types
+```
+
+### Feature Flags
+```toml
+[features]
+default = []
+client = []           # Client-side state management
+rpc = ["client"]      # RPC extensions (requires client)
+```
+
+## Implementation Phases
+
+### Phase 1: Core Client State Management
+
+**Goal:** Enable follower nodes to receive and track flashblock state.
+
+**Files to create:**
+
+| File | Source | Changes Required |
+|------|--------|------------------|
+| `client/mod.rs` | New | Module exports |
+| `client/state.rs` | `node-reth/state.rs` | Replace `base_flashtypes::Flashblock` with `FlashBlock` |
+| `client/processor.rs` | `node-reth/processor.rs` | Same type replacements, generalize over chain spec |
+| `client/pending_blocks.rs` | `node-reth/pending_blocks.rs` | Use reth RPC types |
+| `client/state_builder.rs` | `node-reth/state_builder.rs` | Already uses reth types |
+
+**New traits:**
+```rust
+/// Core API for accessing flashblock state.
+pub trait FlashblocksClientAPI {
+    /// Retrieves the pending blocks.
+    fn pending_blocks(&self) -> Option<Arc<ClientPendingBlocks>>;
+
+    /// Subscribes to flashblock updates.
+    fn subscribe(&self) -> broadcast::Receiver<Arc<ClientPendingBlocks>>;
+}
+
+/// API for querying pending block data.
+pub trait PendingBlocksAPI {
+    fn get_block(&self, full: bool) -> Option<RpcBlock<Optimism>>;
+    fn get_transaction_receipt(&self, hash: TxHash) -> Option<RpcReceipt<Optimism>>;
+    fn get_balance(&self, address: Address) -> Option<U256>;
+    fn get_transaction_count(&self, address: Address) -> U256;
+    fn get_transaction_by_hash(&self, hash: TxHash) -> Option<RpcTransaction<Optimism>>;
+    fn get_pending_logs(&self, filter: &Filter) -> Vec<Log>;
+    fn get_state_overrides(&self) -> Option<StateOverride>;
+}
+```
+
+**Dependencies:**
+- `reth_rpc_eth_api` - RPC types
+- `reth_optimism_primitives` - OP primitives
+- `op_alloy_rpc_types` - OP RPC types
+- Existing flashblocks crate dependencies
+
+**Estimated scope:** ~1000 LOC
+
+---
+
+### Phase 2: RPC Extensions
+
+**Goal:** Enable flashblock-aware RPC methods.
+
+**Files to create:**
+
+| File | Source | Changes Required |
+|------|--------|------------------|
+| `rpc/mod.rs` | New | Module exports |
+| `rpc/eth_ext.rs` | `node-reth/rpc/eth.rs` | Adapt to reth RPC infrastructure |
+| `rpc/pubsub.rs` | `node-reth/rpc/pubsub.rs` | Adapt to reth pubsub |
+| `rpc/types.rs` | `node-reth/rpc/types.rs` | Subscription kind enums |
+
+**RPC methods to support:**
+
+| Method | Behavior |
+|--------|----------|
+| `eth_getBlockByNumber("pending")` | Returns current flashblock |
+| `eth_getTransactionReceipt` | Checks flashblocks first |
+| `eth_getBalance(addr, "pending")` | Returns flashblock balance |
+| `eth_getTransactionCount(addr, "pending")` | Includes flashblock txs |
+| `eth_getTransactionByHash` | Checks flashblocks first |
+| `eth_call(tx, "pending")` | Executes against flashblock state |
+| `eth_estimateGas(tx, "pending")` | Estimates with flashblock state |
+| `eth_getLogs` | Includes pending logs |
+| **`eth_sendRawTransactionSync`** | Wait for flashblock inclusion |
+
+**New subscriptions:**
+
+| Subscription | Description |
+|--------------|-------------|
+| `newFlashblocks` | Stream of new flashblocks |
+| `pendingLogs` | Stream of logs from flashblocks |
+| `newFlashblockTransactions` | Stream of pending transactions |
+
+**Dependencies:**
+- `jsonrpsee` - RPC server
+- `reth_rpc` - Base RPC implementation
+- `reth_rpc_eth_api` - Eth API traits
+
+**Estimated scope:** ~800 LOC
+
+---
+
+### Phase 3: Node Builder Integration
+
+**Goal:** Easy integration into OP Stack nodes.
+
+**Files to create:**
+
+| File | Description |
+|------|-------------|
+| `client/extension.rs` | Node builder extension trait |
+| `client/config.rs` | Configuration types |
+
+**Integration approach:**
+
+```rust
+/// Configuration for flashblocks client.
+#[derive(Debug, Clone)]
+pub struct FlashblocksClientConfig {
+    /// WebSocket URL for flashblocks stream.
+    pub ws_url: String,
+    /// Maximum pending block depth.
+    pub max_depth: u64,
+    /// Enable RPC extensions.
+    pub enable_rpc: bool,
+}
+
+/// Extension for adding flashblocks client to a node.
+pub trait FlashblocksClientExt {
+    /// Adds flashblocks client support to the node.
+    fn with_flashblocks_client(self, config: FlashblocksClientConfig) -> Self;
+}
+```
+
+**Integration with ExEx:**
+```rust
+// The client uses an ExEx to receive canonical block notifications
+// for reconciliation with flashblock state.
+impl FlashblocksClientExtension {
+    fn install_exex(&self, ctx: &BuilderContext) {
+        ctx.install_exex("flashblocks-reconciler", |ctx| {
+            // Forward canonical blocks to state processor
+        });
+    }
+}
+```
+
+**Estimated scope:** ~300 LOC
+
+---
+
+## Type Mappings
+
+| node-reth | reth (upstream) |
+|-----------|-----------------|
+| `base_flashtypes::Flashblock` | `FlashBlock` (alias for `OpFlashblockPayload`) |
+| `base_client_node::*` | reth node builder APIs |
+| `PendingBlocks` | `ClientPendingBlocks` (renamed to avoid confusion) |
+| `FlashblocksState` | `FlashblocksClientState` |
+| `StateProcessor` | `ClientStateProcessor` |
+
+## Key Decisions
+
+### 1. Naming Convention
+- Prefix client-side types with `Client` to distinguish from builder-side
+- Use `client/` submodule for clear separation
+
+### 2. Feature Organization
+- `client` feature: Core state management (no RPC dependencies)
+- `rpc` feature: RPC extensions (depends on `client`)
+- Default: Neither enabled (builder-only, current behavior)
+
+### 3. Generics
+- Make types generic over chain spec where possible
+- Use associated types for network-specific RPC types
+
+### 4. Shared Code
+- `validation.rs` - Already shared (upstreamed in Phase 1-2 of speculative building)
+- `ws/` - Can be shared for WebSocket connection
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Type incompatibility with `base_flashtypes` | Use `op_alloy_rpc_types_engine::OpFlashblockPayload` (already aliased as `FlashBlock`) |
+| RPC infrastructure differences | Adapt to reth's RPC patterns, may need some refactoring |
+| Breaking changes to builder-side | Feature flags isolate client code |
+| Performance regression | Benchmark critical paths, optimize state access |
+
+## Testing Strategy
+
+### Unit Tests
+- State processor reconciliation logic
+- Pending blocks query methods
+- RPC method behavior with/without flashblock state
+
+### Integration Tests
+- Full flow: WS → State → RPC response
+- Canonical block reconciliation
+- Reorg handling
+
+### Test Harness
+- Extend existing `FlashBlockServiceTestHarness` for client testing
+- Mock flashblock streams
+- Simulated canonical chain updates
+
+## Estimated Total Scope
+
+| Phase | LOC | Complexity |
+|-------|-----|------------|
+| Phase 1: Core Client State | ~1000 | Medium |
+| Phase 2: RPC Extensions | ~800 | Medium-High |
+| Phase 3: Node Integration | ~300 | Low |
+| Tests | ~500 | Medium |
+| **Total** | **~2600** | |
+
+## Open Questions
+
+1. **Should `eth_sendRawTransactionSync` be included?**
+   - Very useful for UX (wait for flashblock inclusion)
+   - Adds complexity (timeout handling, dual listening)
+
+2. **How to handle Base-specific subscription types?**
+   - Option A: Generic subscription system
+   - Option B: OP-specific types in `op_alloy`
+
+3. **Integration with existing reth RPC modules?**
+   - Replace vs extend existing eth_* implementations
+   - node-reth uses `replace_configured` pattern
+
+## Next Steps
+
+1. [ ] Review and approve scope
+2. [ ] Phase 1 implementation
+3. [ ] Phase 1 PR and review
+4. [ ] Phase 2 implementation
+5. [ ] Phase 2 PR and review
+6. [ ] Phase 3 implementation
+7. [ ] Final integration testing
+8. [ ] Documentation updates
+
+## References
+
+- node-reth flashblocks: `node-reth/crates/client/flashblocks/`
+- reth flashblocks: `reth/crates/optimism/flashblocks/`
+- Speculative building design doc: `docs/speculative-building.md`

--- a/crates/optimism/flashblocks/src/cache.rs
+++ b/crates/optimism/flashblocks/src/cache.rs
@@ -482,7 +482,8 @@ mod tests {
         let local_tip_hash = B256::random();
         let local_tip_timestamp = 1000;
 
-        let args = manager.next_buildable_args::<OpPrimitives>(local_tip_hash, local_tip_timestamp, None);
+        let args =
+            manager.next_buildable_args::<OpPrimitives>(local_tip_hash, local_tip_timestamp, None);
         assert!(args.is_none());
     }
 
@@ -577,7 +578,11 @@ mod tests {
         }
 
         // Request with proper timing - should compute state root for index 9
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(args.unwrap().compute_state_root);
     }
@@ -594,7 +599,11 @@ mod tests {
         let base_timestamp = fb0.base.as_ref().unwrap().timestamp;
         manager.insert_flashblock(fb0).unwrap();
 
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(!args.unwrap().compute_state_root);
     }
@@ -618,7 +627,11 @@ mod tests {
         }
 
         // Request with proper timing - should compute state root for index 9
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(!args.unwrap().compute_state_root);
     }
@@ -789,7 +802,8 @@ mod tests {
         };
 
         // With pending parent state, should return args for speculative building
-        let args = manager.next_buildable_args(local_tip_hash, 1000000, Some(pending_state.clone()));
+        let args =
+            manager.next_buildable_args(local_tip_hash, 1000000, Some(pending_state.clone()));
         assert!(args.is_some());
         let build_args = args.unwrap();
         assert!(build_args.pending_parent.is_some());

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -14,6 +14,9 @@ use std::sync::Arc;
 // Included to enable serde feature for OpReceipt type used transitively
 use reth_optimism_primitives as _;
 
+// Used by downstream crates that depend on this crate
+use alloy_rpc_types as _;
+
 mod consensus;
 pub use consensus::FlashBlockConsensusClient;
 
@@ -34,6 +37,9 @@ mod pending_state;
 pub use pending_state::{PendingBlockState, PendingStateRegistry};
 
 pub mod validation;
+
+mod tx_cache;
+pub use tx_cache::TransactionCache;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/optimism/flashblocks/src/tx_cache.rs
+++ b/crates/optimism/flashblocks/src/tx_cache.rs
@@ -1,0 +1,297 @@
+//! Transaction execution caching for flashblock building.
+//!
+//! When flashblocks arrive incrementally, each new flashblock triggers a rebuild of pending
+//! state from all transactions in the sequence. Without caching, this means re-executing
+//! transactions that were already executed when previous flashblocks arrived.
+//!
+//! # Approach
+//!
+//! This module uses cumulative state caching: after executing a sequence of transactions,
+//! the resulting bundle state and receipts are cached. When the next flashblock arrives,
+//! if its transaction list is a continuation of the cached list, execution can resume
+//! from the cached state rather than re-executing from scratch.
+//!
+//! The cache stores:
+//! - Ordered list of executed transaction hashes
+//! - Cumulative bundle state after all cached transactions
+//! - Cumulative receipts for all cached transactions
+//!
+//! # Example
+//!
+//! ```text
+//! Flashblock 0: txs [A, B]
+//!   -> Execute A, B from scratch
+//!   -> Cache: txs=[A,B], bundle=state_after_AB, receipts=[rA, rB]
+//!
+//! Flashblock 1: txs [A, B, C]
+//!   -> Prefix [A, B] matches cache
+//!   -> Initialize state with cached bundle
+//!   -> Execute only C
+//!   -> Cache: txs=[A,B,C], bundle=state_after_ABC, receipts=[rA, rB, rC]
+//!
+//! Flashblock 2 (reorg): txs [A, D, E]
+//!   -> Prefix [A] matches, but tx[1]=D != B
+//!   -> Clear cache, execute A, D, E from scratch
+//! ```
+
+use alloy_primitives::B256;
+use reth_primitives_traits::NodePrimitives;
+use reth_revm::db::BundleState;
+
+/// Cache of transaction execution results for a single block.
+///
+/// Stores cumulative execution state that can be restored to skip re-executing
+/// transactions that have already been processed. The cache is invalidated when:
+/// - A new block starts (different block number)
+/// - A reorg is detected (transaction list diverges from cached prefix)
+/// - Explicitly cleared
+#[derive(Debug)]
+pub struct TransactionCache<N: NodePrimitives> {
+    /// Block number this cache is valid for.
+    block_number: u64,
+    /// Ordered list of transaction hashes that have been executed.
+    executed_tx_hashes: Vec<B256>,
+    /// Cumulative bundle state after executing all cached transactions.
+    cumulative_bundle: BundleState,
+    /// Receipts for all cached transactions, in execution order.
+    receipts: Vec<N::Receipt>,
+}
+
+impl<N: NodePrimitives> Default for TransactionCache<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N: NodePrimitives> TransactionCache<N> {
+    /// Creates a new empty transaction cache.
+    pub fn new() -> Self {
+        Self {
+            block_number: 0,
+            executed_tx_hashes: Vec::new(),
+            cumulative_bundle: BundleState::default(),
+            receipts: Vec::new(),
+        }
+    }
+
+    /// Creates a new cache for a specific block number.
+    pub fn for_block(block_number: u64) -> Self {
+        Self { block_number, ..Self::new() }
+    }
+
+    /// Returns the block number this cache is valid for.
+    pub const fn block_number(&self) -> u64 {
+        self.block_number
+    }
+
+    /// Checks if this cache is valid for the given block number.
+    pub const fn is_valid_for_block(&self, block_number: u64) -> bool {
+        self.block_number == block_number
+    }
+
+    /// Returns the number of cached transactions.
+    pub const fn len(&self) -> usize {
+        self.executed_tx_hashes.len()
+    }
+
+    /// Returns true if the cache is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.executed_tx_hashes.is_empty()
+    }
+
+    /// Returns the cached transaction hashes.
+    pub fn executed_tx_hashes(&self) -> &[B256] {
+        &self.executed_tx_hashes
+    }
+
+    /// Returns the cached receipts.
+    pub fn receipts(&self) -> &[N::Receipt] {
+        &self.receipts
+    }
+
+    /// Returns the cumulative bundle state.
+    pub const fn bundle(&self) -> &BundleState {
+        &self.cumulative_bundle
+    }
+
+    /// Clears the cache.
+    pub fn clear(&mut self) {
+        self.executed_tx_hashes.clear();
+        self.cumulative_bundle = BundleState::default();
+        self.receipts.clear();
+        self.block_number = 0;
+    }
+
+    /// Updates the cache for a new block, clearing if the block number changed.
+    ///
+    /// Returns true if the cache was cleared.
+    pub fn update_for_block(&mut self, block_number: u64) -> bool {
+        if self.block_number == block_number {
+            false
+        } else {
+            self.clear();
+            self.block_number = block_number;
+            true
+        }
+    }
+
+    /// Computes the length of the matching prefix between cached transactions
+    /// and the provided transaction hashes.
+    ///
+    /// Returns the number of transactions that can be skipped because they
+    /// match the cached execution results.
+    pub fn matching_prefix_len(&self, tx_hashes: &[B256]) -> usize {
+        self.executed_tx_hashes
+            .iter()
+            .zip(tx_hashes.iter())
+            .take_while(|(cached, incoming)| cached == incoming)
+            .count()
+    }
+
+    /// Returns cached state for resuming execution if the incoming transactions
+    /// have a matching prefix with the cache.
+    ///
+    /// Returns `Some((bundle, receipts, skip_count))` if there's a non-empty matching
+    /// prefix, where:
+    /// - `bundle` is the cumulative state after the matching prefix
+    /// - `receipts` is the receipts for the matching prefix
+    /// - `skip_count` is the number of transactions to skip
+    ///
+    /// Returns `None` if:
+    /// - The cache is empty
+    /// - No prefix matches (first transaction differs)
+    /// - Block number doesn't match
+    pub fn get_resumable_state(
+        &self,
+        block_number: u64,
+        tx_hashes: &[B256],
+    ) -> Option<(&BundleState, &[N::Receipt], usize)> {
+        if !self.is_valid_for_block(block_number) || self.is_empty() {
+            return None;
+        }
+
+        let prefix_len = self.matching_prefix_len(tx_hashes);
+        if prefix_len == 0 {
+            return None;
+        }
+
+        // Only return state if the full cache matches (partial prefix would need
+        // intermediate state snapshots, which we don't currently store).
+        // Partial match means incoming txs diverge from cache, need to re-execute.
+        (prefix_len == self.executed_tx_hashes.len()).then_some((
+            &self.cumulative_bundle,
+            self.receipts.as_slice(),
+            prefix_len,
+        ))
+    }
+
+    /// Updates the cache with new execution results.
+    ///
+    /// This should be called after executing a flashblock. The provided bundle
+    /// and receipts should represent the cumulative state after all transactions.
+    pub fn update(
+        &mut self,
+        block_number: u64,
+        tx_hashes: Vec<B256>,
+        bundle: BundleState,
+        receipts: Vec<N::Receipt>,
+    ) {
+        self.block_number = block_number;
+        self.executed_tx_hashes = tx_hashes;
+        self.cumulative_bundle = bundle;
+        self.receipts = receipts;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_optimism_primitives::OpPrimitives;
+
+    type TestCache = TransactionCache<OpPrimitives>;
+
+    #[test]
+    fn test_cache_block_validation() {
+        let mut cache = TestCache::for_block(100);
+        assert!(cache.is_valid_for_block(100));
+        assert!(!cache.is_valid_for_block(101));
+
+        // Update for same block doesn't clear
+        assert!(!cache.update_for_block(100));
+
+        // Update for different block clears
+        assert!(cache.update_for_block(101));
+        assert!(cache.is_valid_for_block(101));
+    }
+
+    #[test]
+    fn test_cache_clear() {
+        let mut cache = TestCache::for_block(100);
+        assert_eq!(cache.block_number(), 100);
+
+        cache.clear();
+        assert_eq!(cache.block_number(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_matching_prefix_len() {
+        let mut cache = TestCache::for_block(100);
+
+        let tx_a = B256::repeat_byte(0xAA);
+        let tx_b = B256::repeat_byte(0xBB);
+        let tx_c = B256::repeat_byte(0xCC);
+        let tx_d = B256::repeat_byte(0xDD);
+
+        // Update cache with [A, B]
+        cache.update(100, vec![tx_a, tx_b], BundleState::default(), vec![]);
+
+        // Full match
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_b]), 2);
+
+        // Continuation
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_b, tx_c]), 2);
+
+        // Partial match (reorg at position 1)
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_d, tx_c]), 1);
+
+        // No match (reorg at position 0)
+        assert_eq!(cache.matching_prefix_len(&[tx_d, tx_b, tx_c]), 0);
+
+        // Empty incoming
+        assert_eq!(cache.matching_prefix_len(&[]), 0);
+    }
+
+    #[test]
+    fn test_get_resumable_state() {
+        let mut cache = TestCache::for_block(100);
+
+        let tx_a = B256::repeat_byte(0xAA);
+        let tx_b = B256::repeat_byte(0xBB);
+        let tx_c = B256::repeat_byte(0xCC);
+
+        // Empty cache returns None
+        assert!(cache.get_resumable_state(100, &[tx_a, tx_b]).is_none());
+
+        // Update cache with [A, B]
+        cache.update(100, vec![tx_a, tx_b], BundleState::default(), vec![]);
+
+        // Wrong block number returns None
+        assert!(cache.get_resumable_state(101, &[tx_a, tx_b]).is_none());
+
+        // Exact match returns state
+        let result = cache.get_resumable_state(100, &[tx_a, tx_b]);
+        assert!(result.is_some());
+        let (_, _, skip) = result.unwrap();
+        assert_eq!(skip, 2);
+
+        // Continuation returns state (can skip cached txs)
+        let result = cache.get_resumable_state(100, &[tx_a, tx_b, tx_c]);
+        assert!(result.is_some());
+        let (_, _, skip) = result.unwrap();
+        assert_eq!(skip, 2);
+
+        // Partial match (reorg) returns None - can't use partial cache
+        assert!(cache.get_resumable_state(100, &[tx_a, tx_c]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Add cumulative state caching to avoid re-executing unchanged transactions when new flashblocks arrive.

Part of the [speculative flashblock building design](https://www.notion.so/oplabs/Flashblocks-Upstreaming-node-reth-features-2e8f153ee162805eaaa5f067fe3440a3?source=copy_link). Builds on [PR 3](https://github.com/op-rs/op-reth/pull/592), and will be rebased to target https://github.com/paradigmxyz/reth once it merges.

## Motivation

When a new flashblock arrives, the builder re-executes all transactions from all flashblocks in the sequence. For a block with 10 flashblocks of 50 transactions each, this means 2,750 total executions instead of 500.

By caching the cumulative state after execution, we can resume from cached state when the incoming transaction list is a continuation of what was previously executed.

## Changes

**`tx_cache.rs`** (new)
- `TransactionCache<N>` stores:
  - Block number the cache is valid for
  - Ordered list of executed transaction hashes
  - Cumulative `BundleState` after all cached transactions
  - Receipts for all cached transactions
- `get_resumable_state()` - Returns cached bundle/receipts/skip_count if incoming transactions have matching prefix
- `matching_prefix_len()` - Computes overlap between cached and incoming transaction lists
- Cache cleared on block change or explicit `clear()`

**`worker.rs`**
- Accept optional `&mut TransactionCache<N>` in `execute()`
- Check cache for resumable state (canonical mode only)
- Use `with_bundle_prestate()` to restore cached state (same mechanism as speculative execution)
- Skip already-executed transactions, combine cached receipts with new receipts
- Update cache after successful execution

**`service.rs`**
- Add `tx_cache: TransactionCache<N>` field
- Transfer cache ownership to spawned build tasks via `std::mem::take()`
- Return cache with build results, restore after task completion
- Clear cache on reorg, catch-up, or depth limit exceeded

## Testing

Unit tests in `tx_cache.rs`:
- Block validation and clearing
- Prefix matching with exact match, continuation, partial match, no match
- `get_resumable_state()` behavior with wrong block, empty cache, partial prefix
