### PR TITLE
chore(trie): Use `reth-trie-common` to enable `serde-bincode-compat` in v1.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10203,6 +10203,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-trie",
+ "reth-trie-common",
  "secp256k1 0.30.0",
  "serde",
  "serial_test",

--- a/crates/optimism/trie/Cargo.toml
+++ b/crates/optimism/trie/Cargo.toml
@@ -20,6 +20,7 @@ reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true
 reth-trie = { workspace = true, features = ["serde"] }
+reth-trie-common = { workspace = true, features = ["serde"] }
 reth-tasks.workspace = true
 
 # `metrics` feature
@@ -74,7 +75,7 @@ serial_test.workspace = true
 [features]
 serde-bincode-compat = [
     "reth-primitives-traits/serde-bincode-compat",
-    "reth-trie/serde-bincode-compat",
+    "reth-trie-common/serde-bincode-compat",
     "alloy-consensus/serde-bincode-compat",
     "alloy-eips/serde-bincode-compat",
     "alloy-genesis/serde-bincode-compat",

--- a/crates/optimism/trie/src/api.rs
+++ b/crates/optimism/trie/src/api.rs
@@ -9,8 +9,9 @@ use reth_primitives_traits::Account;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
-    updates::TrieUpdatesSorted,
-    BranchNodeCompact, HashedPostStateSorted, Nibbles,
+};
+use reth_trie_common::{
+    updates::TrieUpdatesSorted, BranchNodeCompact, HashedPostStateSorted, Nibbles,
 };
 use std::{fmt::Debug, time::Duration};
 

--- a/crates/optimism/trie/src/api.rs
+++ b/crates/optimism/trie/src/api.rs
@@ -14,8 +14,7 @@ use reth_trie::{
     trie_cursor::{TrieCursor, TrieStorageCursor},
 };
 use reth_trie_common::{
-    updates::TrieUpdatesSorted, BranchNodeCompact, HashedPostStateSorted, Nibbles,
-StoredNibbles,
+    updates::TrieUpdatesSorted, BranchNodeCompact, HashedPostStateSorted, Nibbles, StoredNibbles,
 };
 use std::{fmt::Debug, time::Duration};
 

--- a/crates/optimism/trie/src/backfill.rs
+++ b/crates/optimism/trie/src/backfill.rs
@@ -9,7 +9,7 @@ use reth_db::{
     DatabaseError,
 };
 use reth_primitives_traits::{Account, StorageEntry};
-use reth_trie::{BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles};
+use reth_trie_common::{BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles};
 use std::{collections::HashMap, time::Instant};
 use tracing::info;
 
@@ -371,20 +371,20 @@ mod tests {
     use reth_primitives_traits::Account;
     use reth_trie::{
         hashed_cursor::HashedCursor, trie_cursor::TrieCursor, BranchNodeCompact, StorageTrieEntry,
-        StoredNibbles, StoredNibblesSubKey,
+        StoredNibbles, StoredNibblesSubKey, TrieMask,
     };
     use std::sync::Arc;
 
     /// Helper function to create a test branch node
     fn create_test_branch_node() -> BranchNodeCompact {
-        let mut state_mask = reth_trie::TrieMask::default();
+        let mut state_mask = TrieMask::default();
         state_mask.set_bit(0);
         state_mask.set_bit(1);
 
         BranchNodeCompact {
             state_mask,
-            tree_mask: reth_trie::TrieMask::default(),
-            hash_mask: reth_trie::TrieMask::default(),
+            tree_mask: TrieMask::default(),
+            hash_mask: TrieMask::default(),
             hashes: Arc::new(vec![]),
             root_hash: None,
         }

--- a/crates/optimism/trie/src/backfill.rs
+++ b/crates/optimism/trie/src/backfill.rs
@@ -14,8 +14,9 @@ use reth_db::{
     DatabaseError,
 };
 use reth_primitives_traits::{Account, StorageEntry};
-use reth_trie_common::{BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles,
-StoredNibblesSubKey};
+use reth_trie_common::{
+    BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
+};
 use std::{collections::HashMap, time::Instant};
 use tracing::info;
 

--- a/crates/optimism/trie/src/cursor.rs
+++ b/crates/optimism/trie/src/cursor.rs
@@ -8,8 +8,8 @@ use reth_primitives_traits::Account;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
-    BranchNodeCompact, Nibbles,
 };
+use reth_trie_common::{BranchNodeCompact, Nibbles};
 
 /// Manages reading storage or account trie nodes from [`TrieCursor`].
 #[derive(Debug, Clone, Constructor)]

--- a/crates/optimism/trie/src/db/cursor.rs
+++ b/crates/optimism/trie/src/db/cursor.rs
@@ -18,8 +18,8 @@ use reth_primitives_traits::Account;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
-    BranchNodeCompact, Nibbles, StoredNibbles,
 };
+use reth_trie_common::{BranchNodeCompact, Nibbles, StoredNibbles};
 
 /// Generic alias for dup cursor for T
 pub(crate) type Dup<'tx, T> = <<DatabaseEnv as Database>::TX as DbTx>::DupCursor<T>;

--- a/crates/optimism/trie/src/db/models/change_set.rs
+++ b/crates/optimism/trie/src/db/models/change_set.rs
@@ -4,7 +4,7 @@ use reth_db::{
     table::{self, Decode, Encode},
     DatabaseError,
 };
-use reth_trie::StoredNibbles;
+use reth_trie_common::StoredNibbles;
 use serde::{Deserialize, Serialize};
 
 /// The keys of the entries in the history tables.

--- a/crates/optimism/trie/src/db/models/kv.rs
+++ b/crates/optimism/trie/src/db/models/kv.rs
@@ -5,7 +5,7 @@ use crate::db::{
 use alloy_primitives::B256;
 use reth_db::table::{DupSort, Table};
 use reth_primitives_traits::Account;
-use reth_trie::{BranchNodeCompact, Nibbles, StoredNibbles};
+use reth_trie_common::{BranchNodeCompact, Nibbles, StoredNibbles};
 
 /// Helper to convert inputs into a table key or kv pair.
 pub trait IntoKV<Tab: Table + DupSort> {

--- a/crates/optimism/trie/src/db/models/mod.rs
+++ b/crates/optimism/trie/src/db/models/mod.rs
@@ -22,7 +22,7 @@ use reth_db::{
     tables, TableSet, TableType, TableViewer,
 };
 use reth_primitives_traits::Account;
-use reth_trie::{BranchNodeCompact, StoredNibbles};
+use reth_trie_common::{BranchNodeCompact, StoredNibbles};
 use std::fmt;
 
 tables! {

--- a/crates/optimism/trie/src/db/models/storage.rs
+++ b/crates/optimism/trie/src/db/models/storage.rs
@@ -4,7 +4,7 @@ use reth_db::{
     table::{Compress, Decode, Decompress, Encode},
     DatabaseError,
 };
-use reth_trie::StoredNibbles;
+use reth_trie_common::StoredNibbles;
 use serde::{Deserialize, Serialize};
 
 /// Composite key: `(hashed-address, path)` for storage trie branches

--- a/crates/optimism/trie/src/db/store.rs
+++ b/crates/optimism/trie/src/db/store.rs
@@ -24,9 +24,8 @@ use reth_db::{
     Database, DatabaseEnv, DatabaseError,
 };
 use reth_primitives_traits::Account;
-use reth_trie::{
-    hashed_cursor::HashedCursor,
-    trie_cursor::TrieCursor,
+use reth_trie::{hashed_cursor::HashedCursor, trie_cursor::TrieCursor};
+use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
     BranchNodeCompact, HashedPostState, Nibbles,
 };

--- a/crates/optimism/trie/src/error.rs
+++ b/crates/optimism/trie/src/error.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use reth_db::DatabaseError;
 use reth_execution_errors::BlockExecutionError;
 use reth_provider::ProviderError;
-use reth_trie::Nibbles;
+use reth_trie_common::Nibbles;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::TryLockError;

--- a/crates/optimism/trie/src/in_memory.rs
+++ b/crates/optimism/trie/src/in_memory.rs
@@ -10,8 +10,9 @@ use reth_primitives_traits::Account;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
-    updates::TrieUpdatesSorted,
-    BranchNodeCompact, HashedPostStateSorted, Nibbles,
+};
+use reth_trie_common::{
+    updates::TrieUpdatesSorted, BranchNodeCompact, HashedPostStateSorted, Nibbles,
 };
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;

--- a/crates/optimism/trie/src/live.rs
+++ b/crates/optimism/trie/src/live.rs
@@ -14,7 +14,7 @@ use reth_provider::{
     StateRootProvider,
 };
 use reth_revm::database::StateProviderDatabase;
-use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
+use reth_trie_common::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use std::{sync::Arc, time::Instant};
 use tracing::info;
 

--- a/crates/optimism/trie/src/metrics.rs
+++ b/crates/optimism/trie/src/metrics.rs
@@ -14,8 +14,8 @@ use reth_primitives_traits::Account;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedStorageCursor},
     trie_cursor::{TrieCursor, TrieStorageCursor},
-    BranchNodeCompact, Nibbles,
 };
+use reth_trie_common::{BranchNodeCompact, Nibbles};
 use std::{
     fmt::Debug,
     future::Future,

--- a/crates/optimism/trie/src/proof.rs
+++ b/crates/optimism/trie/src/proof.rs
@@ -12,12 +12,14 @@ use reth_execution_errors::{StateProofError, StateRootError, StorageRootError, T
 use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory,
     metrics::TrieRootMetrics,
-    proof::{Proof, StorageProof},
+    proof::{self, Proof},
     trie_cursor::InMemoryTrieCursorFactory,
-    updates::TrieUpdates,
     witness::TrieWitness,
-    AccountProof, HashedPostState, HashedPostStateSorted, HashedStorage, MultiProof,
-    MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot, TrieInput, TrieType,
+    StateRoot, StorageRoot, TrieType,
+};
+use reth_trie_common::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedPostStateSorted, HashedStorage,
+    MultiProof, MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 
 /// Extends [`Proof`] with operations specific for working with [`OpProofsStorage`].
@@ -114,7 +116,7 @@ pub trait DatabaseStorageProof<'tx, S> {
         address: Address,
         slot: B256,
         storage: HashedStorage,
-    ) -> Result<reth_trie::StorageProof, StateProofError>;
+    ) -> Result<StorageProof, StateProofError>;
 
     /// Generates the storage multiproof for target slots based on [`TrieInput`].
     fn overlay_storage_multiproof(
@@ -127,7 +129,7 @@ pub trait DatabaseStorageProof<'tx, S> {
 }
 
 impl<'tx, S> DatabaseStorageProof<'tx, S>
-    for StorageProof<
+    for proof::StorageProof<
         'static,
         OpProofsTrieCursorFactory<'tx, S>,
         OpProofsHashedAccountCursorFactory<'tx, S>,
@@ -150,7 +152,7 @@ where
         address: Address,
         slot: B256,
         hashed_storage: HashedStorage,
-    ) -> Result<reth_trie::StorageProof, StateProofError> {
+    ) -> Result<StorageProof, StateProofError> {
         let hashed_address = keccak256(address);
         let prefix_set = hashed_storage.construct_prefix_set();
         let state_sorted = HashedPostStateSorted::new(

--- a/crates/optimism/trie/src/provider.rs
+++ b/crates/optimism/trie/src/provider.rs
@@ -20,11 +20,13 @@ use reth_revm::{
 };
 use reth_trie::{
     hashed_cursor::HashedCursor,
-    proof::{Proof, StorageProof},
-    updates::TrieUpdates,
+    proof::{self, Proof},
     witness::TrieWitness,
-    AccountProof, HashedPostState, HashedStorage, KeccakKeyHasher, MultiProof, MultiProofTargets,
-    StateRoot, StorageMultiProof, StorageRoot, TrieInput,
+    StateRoot, StorageRoot,
+};
+use reth_trie_common::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, KeccakKeyHasher,
+    MultiProof, MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 use std::fmt::Debug;
 
@@ -112,9 +114,15 @@ impl<'a, Storage: OpProofsStore + Clone> StorageRootProvider
         address: Address,
         slot: B256,
         storage: HashedStorage,
-    ) -> ProviderResult<reth_trie::StorageProof> {
-        StorageProof::overlay_storage_proof(self.storage, self.block_number, address, slot, storage)
-            .map_err(ProviderError::from)
+    ) -> ProviderResult<StorageProof> {
+        proof::StorageProof::overlay_storage_proof(
+            self.storage,
+            self.block_number,
+            address,
+            slot,
+            storage,
+        )
+        .map_err(ProviderError::from)
     }
 
     fn storage_multiproof(
@@ -123,7 +131,7 @@ impl<'a, Storage: OpProofsStore + Clone> StorageRootProvider
         slots: &[B256],
         storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
-        StorageProof::overlay_storage_multiproof(
+        proof::StorageProof::overlay_storage_multiproof(
             self.storage,
             self.block_number,
             address,

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -96,13 +96,6 @@ test-utils = [
     "reth-trie-sparse/test-utils",
     "reth-stages-types/test-utils",
 ]
-serde-bincode-compat = [
-    "alloy-consensus/serde-bincode-compat",
-    "alloy-eips/serde-bincode-compat",
-    "reth-ethereum-primitives/serde-bincode-compat",
-    "reth-primitives-traits/serde-bincode-compat",
-    "reth-trie-common/serde-bincode-compat",
-]
 
 [[bench]]
 name = "hash_post_state"


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/611

Uses `reth-trie-common` dep explicitly in `reth-optimism-trie` to make sure `serde-bincode-compat` can be enabled while using reth release v1.10.1