### PR TITLE
chore(deps): Use stable deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,8 +8,10 @@ ignore = [
     "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, used by reth-nippy-jar
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
+    #  https://rustsec.org/advisories/RUSTSEC-2026-0002 lru unused directly: <https://github.com/alloy-rs/alloy/pull/3460>
+    "RUSTSEC-2026-0002",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -55,6 +57,7 @@ allow = [
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
     "LicenseRef-rustls-webpki",
     "CDLA-Permissive-2.0",
+    "MPL-2.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
@@ -63,6 +66,7 @@ exceptions = [
     # TODO: decide on MPL-2.0 handling
     # These dependencies are grandfathered in https://github.com/paradigmxyz/reth/pull/6980
     { allow = ["MPL-2.0"], name = "option-ext" },
+    { allow = ["MPL-2.0"], name = "webpki-root-certs" },
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/611

Checks out deny.toml from stable branch 