### PR TITLE
chore: use reth versioned deps

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,12 +15,3 @@ slow-timeout = { period = "2m", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = "binary(e2e_testsuite)"
 slow-timeout = { period = "2m", terminate-after = 3 }
-
-[[profile.default.overrides]]
-filter = "package(reth-era) and binary(it)"
-slow-timeout = { period = "2m", terminate-after = 10 }
-
-# Allow slower ethereum node e2e tests (p2p + blobs) to run up to 5 minutes.
-[[profile.default.overrides]]
-filter = "package(reth-node-ethereum) and binary(e2e)"
-slow-timeout = { period = "1m", terminate-after = 5 }

--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -3,39 +3,39 @@ set +e  # Disable immediate exit on error
 
 # Array of crates to check
 crates_to_check=(
-    reth-codecs-derive
-    reth-primitives
-    reth-primitives-traits
-    reth-network-peers
-    reth-trie-common
-    reth-trie-sparse
-    reth-chainspec
-    reth-consensus
-    reth-consensus-common
-    reth-prune-types
-    reth-static-file-types
-    reth-storage-errors
-    reth-execution-errors
-    reth-errors
-    reth-execution-types
-    reth-db-models
-    reth-evm
-    reth-revm
-    reth-storage-api
+    #reth-codecs-derive
+    #reth-primitives
+    #reth-primitives-traits
+    #reth-network-peers
+    #reth-trie-common
+    #reth-trie-sparse
+    #reth-chainspec
+    #reth-consensus
+    #reth-consensus-common
+    #reth-prune-types
+    #reth-static-file-types
+    #reth-storage-errors
+    #reth-execution-errors
+    #reth-errors
+    #reth-execution-types
+    #reth-db-models
+    #reth-evm
+    #reth-revm
+    #reth-storage-api
 
     ## ethereum
-    reth-evm-ethereum
-    reth-ethereum-forks
-    reth-ethereum-primitives
-    reth-ethereum-consensus
-    reth-stateless
+    #reth-evm-ethereum
+    #reth-ethereum-forks
+    #reth-ethereum-primitives
+    #reth-ethereum-consensus
+    #reth-stateless
 
     ## optimism
-    reth-optimism-chainspec
-    reth-optimism-forks
-    reth-optimism-consensus
-    reth-optimism-primitives
-    reth-optimism-evm
+    #reth-optimism-chainspec
+    #reth-optimism-forks
+    #reth-optimism-consensus
+    #reth-optimism-primitives
+    #reth-optimism-evm
 )
 
 # Array to hold the results

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,11 +1,13 @@
 # Runs benchmarks.
 
+# Benchmarks are currently disabled as the relevant crates are git dependencies.
 on:
-  pull_request:
+  workflow_dispatch:
+  # pull_request:
   # TODO: Disabled temporarily for https://github.com/CodSpeedHQ/runner/issues/55
   # merge_group:
-  push:
-    branches: [unstable, main]
+  # push:
+  #   branches: [unstable, main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        network: ["ethereum", "optimism"]
+        network: ["optimism"]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -66,19 +66,3 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-
-  era-files:
-    name: era1 file integration tests once a day
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: run era1 files integration tests
-        run: cargo nextest run --release --package reth-era --test it -- --ignored

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - type: ethereum
             args: --workspace --lib --examples --tests --benches --locked
-            features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+            features: "asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
     steps:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
@@ -77,24 +77,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install gcc-multilib
           .github/assets/check_wasm.sh
-
-  riscv:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v6
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          target: riscv32imac-unknown-none-elf
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - uses: dcarbone/install-jq-action@v3
-      - name: Run RISC-V checks
-        run: .github/assets/check_rv32imac.sh
 
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
@@ -243,35 +225,6 @@ jobs:
       - name: Ensure no arbitrary or proptest dependency on default build
         run: cargo tree --package reth -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0
 
-  # Checks that selected crates can compile with power set of features
-  features:
-    name: features
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        partition: [1, 2]
-        total_partitions: [2]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: cargo install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - run: |
-          cargo hack check \
-            --package reth-codecs \
-            --package reth-primitives-traits \
-            --package reth-primitives \
-            --feature-powerset \
-            --depth 2
-        env:
-          RUSTFLAGS: -D warnings
-
   # Check crates correctly propagate features
   feature-propagation:
     runs-on: ubuntu-latest
@@ -307,7 +260,6 @@ jobs:
       - typos
       - grafana
       - no-test-deps
-      - features
       - feature-propagation
       - deny
     timeout-minutes: 30

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,6 +78,24 @@ jobs:
           sudo apt update && sudo apt install gcc-multilib
           .github/assets/check_wasm.sh
 
+  riscv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: riscv32imac-unknown-none-elf
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: dcarbone/install-jq-action@v3
+      - name: Run RISC-V checks
+        run: .github/assets/check_rv32imac.sh
+
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
     runs-on: ubuntu-latest
@@ -225,6 +243,35 @@ jobs:
       - name: Ensure no arbitrary or proptest dependency on default build
         run: cargo tree --package reth -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0
 
+  # Checks that selected crates can compile with power set of features
+  features:
+    name: features
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2]
+        total_partitions: [2]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: |
+          cargo hack check \
+            --all-targets \
+            --package reth-optimism-trie \
+            --package reth-optimism-exex \
+            --feature-powerset \
+            --depth 2
+        env:
+          RUSTFLAGS: -D warnings
+
   # Check crates correctly propagate features
   feature-propagation:
     runs-on: ubuntu-latest
@@ -260,6 +307,7 @@ jobs:
       - typos
       - grafana
       - no-test-deps
+      - features
       - feature-propagation
       - deny
     timeout-minutes: 30

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -51,7 +51,7 @@ jobs:
           cargo nextest run \
             --features "${{ matrix.features }} $EDGE_FEATURES" --locked \
             ${{ matrix.exclude_args }} --workspace \
-            --no-tests=warn \
+            --exclude ef-tests --no-tests=warn \
             -E "!kind(test) and not binary(e2e_testsuite)"
 
   doc:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,12 +26,9 @@ jobs:
       EDGE_FEATURES: ${{ matrix.storage == 'edge' && 'edge' || '' }}
     strategy:
       matrix:
-        type: [ethereum, optimism]
+        type: [optimism]
         storage: [stable, edge]
         include:
-          - type: ethereum
-            features: asm-keccak ethereum
-            exclude_args: ""
           - type: optimism
             features: asm-keccak
             exclude_args: --exclude reth --exclude reth-bench --exclude "example-*" --exclude "reth-ethereum-*" --exclude "*-ethereum"
@@ -54,43 +51,8 @@ jobs:
           cargo nextest run \
             --features "${{ matrix.features }} $EDGE_FEATURES" --locked \
             ${{ matrix.exclude_args }} --workspace \
-            --exclude ef-tests --no-tests=warn \
+            --no-tests=warn \
             -E "!kind(test) and not binary(e2e_testsuite)"
-
-  state:
-    name: Ethereum state tests
-    runs-on: ubuntu-latest
-    env:
-      RUST_LOG: info,sync=error
-      RUST_BACKTRACE: 1
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - name: Checkout ethereum/tests
-        uses: actions/checkout@v6
-        with:
-          repository: ethereum/tests
-          ref: 81862e4848585a438d64f911a19b3825f0f4cd95
-          path: testing/ef-tests/ethereum-tests
-          submodules: recursive
-          fetch-depth: 1
-      - name: Download & extract EEST fixtures (public)
-        shell: bash
-        env:
-          EEST_TESTS_TAG: v4.5.0
-        run: |
-          set -euo pipefail
-          mkdir -p testing/ef-tests/execution-spec-tests
-          URL="https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_TESTS_TAG}/fixtures_stable.tar.gz"
-          curl -L "$URL" | tar -xz --strip-components=1 -C testing/ef-tests/execution-spec-tests
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo nextest run --release -p ef-tests --features "asm-keccak ef-tests"
 
   doc:
     name: doc tests
@@ -113,7 +75,7 @@ jobs:
     name: unit success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, state, doc]
+    needs: [test, doc]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,6 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "arbitrary",
  "serde_core",
 ]
 
@@ -2109,6 +2108,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "coins-bip32"
@@ -5538,15 +5546,15 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-node-builder",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
  "reth-optimism-cli",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
  "reth-optimism-exex",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks",
  "reth-optimism-node",
- "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-payload-builder",
+ "reth-optimism-primitives",
  "reth-optimism-rpc",
  "reth-optimism-trie",
  "reth-tasks",
@@ -6582,12 +6590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,6 +6637,53 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "reth"
+version = "1.10.1"
+dependencies = [
+ "alloy-rpc-types",
+ "aquamarine",
+ "backon",
+ "clap",
+ "eyre",
+ "reth-chainspec",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
+ "reth-ethereum-cli",
+ "reth-ethereum-payload-builder",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-network",
+ "reth-network-api",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-node-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-ress-protocol",
+ "reth-ress-provider",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-convert",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-tasks",
+ "reth-tokio-util",
+ "reth-transaction-pool",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "reth-basic-payload-builder"
@@ -6834,6 +6883,7 @@ dependencies = [
  "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
+ "snmalloc-rs",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tracy-client",
@@ -6980,7 +7030,7 @@ dependencies = [
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
@@ -7243,7 +7293,7 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -7504,6 +7554,28 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-ethereum-cli"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-cli-commands",
+ "reth-cli-runner",
+ "reth-db",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-node-metrics",
+ "reth-rpc-server-types",
+ "reth-tracing",
+ "tracing",
 ]
 
 [[package]]
@@ -8319,74 +8391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-op"
-version = "1.10.1"
-dependencies = [
- "reth-chainspec",
- "reth-cli-util",
- "reth-codecs",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-engine-local",
- "reth-eth-wire",
- "reth-evm",
- "reth-exex",
- "reth-network",
- "reth-network-api",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-cli",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-node",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-rpc",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-eth-types",
- "reth-storage-api",
- "reth-tasks",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
-]
-
-[[package]]
-name = "reth-optimism-chainspec"
-version = "1.10.1"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-hardforks",
- "alloy-op-hardforks",
- "alloy-primitives",
- "derive_more",
- "miniz_oxide",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "paste",
- "reth-chainspec",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-primitives-traits",
- "serde",
- "serde_json",
- "tar-no-std",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "reth-optimism-chainspec"
 version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
@@ -8405,8 +8409,8 @@ dependencies = [
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "serde",
  "serde_json",
@@ -8443,11 +8447,11 @@ dependencies = [
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
  "reth-optimism-node",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives",
  "reth-optimism-trie",
  "reth-primitives-traits",
  "reth-provider",
@@ -8467,37 +8471,6 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.10.1"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-trie",
- "op-alloy-consensus",
- "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db-common",
- "reth-execution-types",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-node",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-common",
- "revm",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-consensus"
-version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
@@ -8508,9 +8481,9 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8518,35 +8491,6 @@ dependencies = [
  "revm",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "reth-optimism-evm"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-op-evm",
- "alloy-primitives",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "op-revm",
- "reth-chainspec",
- "reth-evm",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-primitives-traits",
- "reth-revm",
- "reth-rpc-eth-api",
- "reth-storage-errors",
- "revm",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8566,10 +8510,10 @@ dependencies = [
  "reth-evm",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-rpc-eth-api",
  "reth-storage-errors",
@@ -8594,7 +8538,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-types",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
  "reth-optimism-node",
  "reth-optimism-trie",
  "reth-primitives-traits",
@@ -8603,44 +8547,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "reth-optimism-flashblocks"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "brotli",
- "derive_more",
- "eyre",
- "futures-util",
- "metrics",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "reth-chain-state",
- "reth-engine-primitives",
- "reth-errors",
- "reth-evm",
- "reth-execution-types",
- "reth-metrics",
- "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-revm",
- "reth-rpc-eth-types",
- "reth-storage-api",
- "reth-tasks",
- "ringbuffer",
- "serde_json",
- "test-case",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -8664,8 +8570,8 @@ dependencies = [
  "reth-evm",
  "reth-execution-types",
  "reth-metrics",
- "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-payload-builder",
+ "reth-optimism-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-revm",
@@ -8678,16 +8584,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "reth-optimism-forks"
-version = "1.10.1"
-dependencies = [
- "alloy-op-hardforks",
- "alloy-primitives",
- "once_cell",
- "reth-ethereum-forks",
 ]
 
 [[package]]
@@ -8730,16 +8626,16 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
+ "reth-optimism-forks",
  "reth-optimism-node",
- "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-payload-builder",
+ "reth-optimism-primitives",
  "reth-optimism-rpc",
- "reth-optimism-storage 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-storage",
+ "reth-optimism-txpool",
  "reth-payload-builder",
  "reth-payload-util",
  "reth-primitives-traits",
@@ -8766,45 +8662,6 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
- "derive_more",
- "either",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "reth-basic-payload-builder",
- "reth-chainspec",
- "reth-evm",
- "reth-execution-types",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-payload-builder",
- "reth-payload-builder-primitives",
- "reth-payload-primitives",
- "reth-payload-util",
- "reth-payload-validator",
- "reth-primitives-traits",
- "reth-revm",
- "reth-storage-api",
- "reth-transaction-pool",
- "revm",
- "serde",
- "sha2",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-payload-builder"
-version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
@@ -8822,10 +8679,10 @@ dependencies = [
  "reth-chainspec",
  "reth-evm",
  "reth-execution-types",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-optimism-txpool",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -8840,33 +8697,6 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "reth-optimism-primitives"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "bincode",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
- "rstest",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "serde_with",
 ]
 
 [[package]]
@@ -8923,14 +8753,14 @@ dependencies = [
  "reth-metrics",
  "reth-node-api",
  "reth-node-builder",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-flashblocks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-chainspec",
+ "reth-optimism-evm",
+ "reth-optimism-flashblocks",
+ "reth-optimism-forks",
+ "reth-optimism-payload-builder",
+ "reth-optimism-primitives",
  "reth-optimism-trie",
- "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-txpool",
  "reth-payload-util",
  "reth-primitives-traits",
  "reth-provider",
@@ -8958,22 +8788,10 @@ dependencies = [
 [[package]]
 name = "reth-optimism-storage"
 version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "reth-codecs",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-api",
-]
-
-[[package]]
-name = "reth-optimism-storage"
-version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives",
  "reth-storage-api",
 ]
 
@@ -9025,43 +8843,6 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "c-kzg",
- "derive_more",
- "futures-util",
- "metrics",
- "op-alloy-consensus",
- "op-alloy-flz",
- "op-alloy-rpc-types",
- "op-revm",
- "parking_lot",
- "reth-chain-state",
- "reth-chainspec",
- "reth-metrics",
- "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-primitives-traits",
- "reth-provider",
- "reth-storage-api",
- "reth-transaction-pool",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-txpool"
-version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
@@ -9083,9 +8864,9 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-metrics",
- "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-transaction-pool",
@@ -9305,6 +9086,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ress-protocol"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "futures",
+ "reth-eth-wire",
+ "reth-ethereum-primitives",
+ "reth-network",
+ "reth-network-api",
+ "reth-storage-errors",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-ress-provider"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "eyre",
+ "futures",
+ "parking_lot",
+ "reth-chain-state",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-node-api",
+ "reth-primitives-traits",
+ "reth-ress-protocol",
+ "reth-revm",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-tokio-util",
+ "reth-trie",
+ "schnellru",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-revm"
 version = "1.10.1"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
@@ -9490,7 +9317,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "thiserror 2.0.18",
@@ -9910,8 +9737,6 @@ dependencies = [
  "parking_lot",
  "paste",
  "pin-project",
- "proptest",
- "proptest-arbitrary-interop",
  "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
@@ -10401,36 +10226,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rstest"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version 0.4.1",
- "syn 2.0.114",
- "unicode-ident",
-]
 
 [[package]]
 name = "ruint"
@@ -11174,6 +10969,25 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
+dependencies = [
+ "cc",
+ "cmake",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,28 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-contract"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990fa65cd132a99d3c3795a82b9f93ec82b81c7de3bab0bf26ca5c73286f7186"
-dependencies = [
- "alloy-consensus",
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
- "futures",
- "futures-util",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-dyn-abi"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +459,6 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-signer",
@@ -671,7 +648,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -975,12 +951,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -1373,23 +1343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,20 +1352,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-sse"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6fa871e4334a622afd6bb2f611635e8083a6f5e2936c0f90f37c7ef9856298"
-dependencies = [
- "async-channel",
- "futures-lite 1.13.0",
- "http-types",
- "log",
- "memchr",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1498,7 +1437,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "tokio",
 ]
 
@@ -1541,12 +1480,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1582,26 +1515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -1719,15 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,7 +1682,7 @@ dependencies = [
  "float16",
  "futures-channel",
  "futures-concurrency",
- "futures-lite 2.6.1",
+ "futures-lite",
  "hashbrown 0.16.1",
  "icu_normalizer",
  "indexmap 2.13.0",
@@ -1944,17 +1848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,20 +1969,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
@@ -2107,12 +1986,6 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -2177,33 +2050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,70 +2111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "codspeed"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
-dependencies = [
- "colored",
- "libc",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "codspeed-criterion-compat"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
-dependencies = [
- "codspeed",
- "codspeed-criterion-compat-walltime",
- "colored",
- "futures",
- "tokio",
-]
-
-[[package]]
-name = "codspeed-criterion-compat-walltime"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "codspeed",
- "criterion-plot",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "tokio",
- "walkdir",
-]
-
-[[package]]
 name = "coins-bip32"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,47 +2162,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "combine"
@@ -2484,27 +2229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2625,16 +2349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,44 +2457,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
-dependencies = [
- "dispatch2",
- "nix 0.30.1",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2808,19 +2490,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "custom-hardforks"
-version = "0.1.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "reth-chainspec",
- "reth-network-peers",
- "serde",
 ]
 
 [[package]]
@@ -3208,18 +2877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
-dependencies = [
- "bitflags 2.10.0",
- "block2",
- "libc",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,47 +2993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ef-test-runner"
-version = "1.10.1"
-dependencies = [
- "clap",
- "ef-tests",
-]
-
-[[package]]
-name = "ef-tests"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "rayon",
- "reth-chainspec",
- "reth-consensus",
- "reth-db",
- "reth-db-api",
- "reth-db-common",
- "reth-ethereum-consensus",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
- "reth-stateless",
- "reth-tracing",
- "reth-trie",
- "reth-trie-db",
- "revm",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,12 +3020,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enr"
@@ -3560,435 +3170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "example-beacon-api-sidecar-fetcher"
-version = "0.1.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-beacon",
- "clap",
- "eyre",
- "futures-util",
- "reqwest",
- "reth-ethereum",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "example-beacon-api-sse"
-version = "0.0.0"
-dependencies = [
- "alloy-rpc-types-beacon",
- "clap",
- "futures-util",
- "mev-share-sse",
- "reth-ethereum",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "example-bsc-p2p"
-version = "0.0.0"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "bytes",
- "futures",
- "reth-chainspec",
- "reth-discv4",
- "reth-engine-primitives",
- "reth-eth-wire",
- "reth-eth-wire-types",
- "reth-ethereum-forks",
- "reth-network",
- "reth-network-api",
- "reth-network-peers",
- "reth-node-ethereum",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-primitives-traits",
- "reth-provider",
- "reth-tracing",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "example-custom-beacon-withdrawals"
-version = "0.0.0"
-dependencies = [
- "alloy-eips",
- "alloy-evm",
- "alloy-sol-macro",
- "alloy-sol-types",
- "eyre",
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-custom-dev-node"
-version = "0.0.0"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "eyre",
- "futures-util",
- "reth-ethereum",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "example-custom-engine-types"
-version = "0.0.0"
-dependencies = [
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rpc-types",
- "eyre",
- "reth-basic-payload-builder",
- "reth-ethereum",
- "reth-ethereum-payload-builder",
- "reth-payload-builder",
- "reth-tracing",
- "serde",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "example-custom-evm"
-version = "0.0.0"
-dependencies = [
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "eyre",
- "reth-ethereum",
- "reth-tracing",
- "tokio",
-]
-
-[[package]]
-name = "example-custom-inspector"
-version = "0.0.0"
-dependencies = [
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "clap",
- "futures-util",
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-custom-node"
-version = "0.0.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-network",
- "alloy-op-evm",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "async-trait",
- "derive_more",
- "eyre",
- "jsonrpsee",
- "modular-bitfield",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
- "op-revm",
- "reth-codecs",
- "reth-db-api",
- "reth-engine-primitives",
- "reth-ethereum",
- "reth-network-peers",
- "reth-node-builder",
- "reth-op",
- "reth-optimism-flashblocks",
- "reth-optimism-forks",
- "reth-payload-builder",
- "reth-rpc-api",
- "reth-rpc-engine-api",
- "revm",
- "revm-primitives",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "example-custom-node-components"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth-ethereum",
- "reth-tracing",
-]
-
-[[package]]
-name = "example-custom-payload-builder"
-version = "0.0.0"
-dependencies = [
- "alloy-eips",
- "eyre",
- "futures-util",
- "reth-basic-payload-builder",
- "reth-ethereum",
- "reth-ethereum-payload-builder",
- "reth-payload-builder",
- "tracing",
-]
-
-[[package]]
-name = "example-custom-rlpx-subprotocol"
-version = "0.0.0"
-dependencies = [
- "alloy-primitives",
- "eyre",
- "futures",
- "reth-ethereum",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "example-custom-rpc-middleware"
-version = "0.0.0"
-dependencies = [
- "clap",
- "jsonrpsee",
- "reth-ethereum",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "example-db-access"
-version = "0.0.0"
-dependencies = [
- "alloy-primitives",
- "eyre",
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-engine-api-access"
-version = "0.0.0"
-dependencies = [
- "reth-db",
- "reth-node-builder",
- "reth-optimism-chainspec",
- "reth-optimism-node",
- "tokio",
-]
-
-[[package]]
-name = "example-exex-hello-world"
-version = "0.0.0"
-dependencies = [
- "clap",
- "eyre",
- "futures",
- "reth-ethereum",
- "reth-op",
- "reth-tracing",
- "tokio",
-]
-
-[[package]]
-name = "example-exex-test"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures-util",
- "reth-e2e-test-utils",
- "reth-ethereum",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "example-full-contract-state"
-version = "1.10.1"
-dependencies = [
- "eyre",
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-manual-p2p"
-version = "0.0.0"
-dependencies = [
- "alloy-consensus",
- "eyre",
- "futures",
- "reth-discv4",
- "reth-ecies",
- "reth-ethereum",
- "reth-network-peers",
- "secp256k1 0.30.0",
- "tokio",
-]
-
-[[package]]
-name = "example-network"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "reth-ethereum",
- "tokio",
-]
-
-[[package]]
-name = "example-network-proxy"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "reth-ethereum",
- "reth-tracing",
- "tokio",
-]
-
-[[package]]
-name = "example-network-txpool"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth-ethereum",
- "tokio",
-]
-
-[[package]]
-name = "example-node-builder-api"
-version = "0.0.0"
-dependencies = [
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-node-custom-rpc"
-version = "0.0.0"
-dependencies = [
- "clap",
- "jsonrpsee",
- "reth-ethereum",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "example-node-event-hooks"
-version = "0.0.0"
-dependencies = [
- "reth-ethereum",
-]
-
-[[package]]
-name = "example-op-db-access"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "reth-op",
-]
-
-[[package]]
-name = "example-polygon-p2p"
-version = "0.0.0"
-dependencies = [
- "alloy-genesis",
- "reth-discv4",
- "reth-ethereum",
- "reth-tracing",
- "secp256k1 0.30.0",
- "serde_json",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "example-precompile-cache"
-version = "0.0.0"
-dependencies = [
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "eyre",
- "parking_lot",
- "reth-ethereum",
- "reth-tracing",
- "schnellru",
- "tokio",
-]
-
-[[package]]
-name = "example-rpc-db"
-version = "0.0.0"
-dependencies = [
- "eyre",
- "futures",
- "jsonrpsee",
- "reth-ethereum",
- "tokio",
-]
-
-[[package]]
-name = "example-txpool-tracing"
-version = "0.0.0"
-dependencies = [
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-trace",
- "clap",
- "eyre",
- "futures-util",
- "reth-ethereum",
-]
-
-[[package]]
-name = "exex-subscription"
-version = "1.10.1"
-dependencies = [
- "alloy-primitives",
- "clap",
- "eyre",
- "futures",
- "jsonrpsee",
- "reth-ethereum",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,15 +3184,6 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "fastrand"
@@ -4233,7 +3405,7 @@ checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
  "fixedbitset",
  "futures-core",
- "futures-lite 2.6.1",
+ "futures-lite",
  "pin-project",
  "smallvec",
 ]
@@ -4263,26 +3435,11 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -4374,17 +3531,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -4392,7 +3538,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -4519,17 +3665,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -4737,26 +3872,6 @@ name = "http-range-header"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
 
 [[package]]
 name = "httparse"
@@ -5100,12 +4215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,18 +4245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "insta"
-version = "1.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248b42847813a1550dafd15296fd9748c651d0c32194559dbc05d804d54b21e8"
-dependencies = [
- "console",
- "once_cell",
- "similar",
- "tempfile",
-]
-
-[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5158,15 +4255,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -5219,17 +4307,6 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5936,33 +5013,11 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
  "metrics",
- "ordered-float",
  "quanta",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mev-share-sse"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9e517b6c1d1143b35b716ec1107a493b2ce1143a35cbb9788e81f69c6f574c"
-dependencies = [
- "alloy-rpc-types-mev",
- "async-sse",
- "bytes",
- "futures-util",
- "http-types",
- "pin-project-lite",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -6021,7 +5076,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -6134,30 +5189,6 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "unsigned-varint",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -6350,21 +5381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6388,12 +5404,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
@@ -6487,7 +5497,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "op-alloy-consensus",
  "serde",
@@ -6507,7 +5516,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6530,15 +5538,15 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-node-builder",
- "reth-optimism-chainspec",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-cli",
- "reth-optimism-consensus",
- "reth-optimism-evm",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-exex",
- "reth-optimism-forks",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
- "reth-optimism-payload-builder",
- "reth-optimism-primitives",
+ "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-rpc",
  "reth-optimism-trie",
  "reth-tasks",
@@ -6682,21 +5690,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "owo-colors"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -6848,7 +5841,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "phf_shared",
 ]
 
@@ -6929,34 +5922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -7049,16 +6014,6 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -7285,7 +6240,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -7383,19 +6338,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -7415,16 +6357,6 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7449,15 +6381,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -7473,15 +6396,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7723,55 +6637,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
-name = "reth"
-version = "1.10.1"
-dependencies = [
- "alloy-rpc-types",
- "aquamarine",
- "backon",
- "clap",
- "eyre",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-ethereum-cli",
- "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-network",
- "reth-network-api",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-metrics",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-provider",
- "reth-ress-protocol",
- "reth-ress-provider",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-convert",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-tasks",
- "reth-tokio-util",
- "reth-transaction-pool",
- "tempfile",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7793,90 +6661,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-bench"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-engine",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
- "async-trait",
- "clap",
- "color-eyre",
- "csv",
- "eyre",
- "futures",
- "humantime",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "reqwest",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-engine-primitives",
- "reth-ethereum-primitives",
- "reth-fs-util",
- "reth-node-api",
- "reth-node-core",
- "reth-primitives-traits",
- "reth-rpc-api",
- "reth-tracing",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tower",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "reth-bench-compare"
-version = "1.10.1"
-dependencies = [
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-transport-ws",
- "chrono",
- "clap",
- "csv",
- "ctrlc",
- "eyre",
- "nix 0.29.0",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-node-core",
- "reth-tracing",
- "serde",
- "serde_json",
- "shellexpand",
- "shlex",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-chain-state"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "parking_lot",
@@ -7889,7 +6682,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
- "reth-testing-utils",
  "reth-trie",
  "revm-database",
  "revm-state",
@@ -7902,6 +6694,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7909,7 +6702,6 @@ dependencies = [
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-trie",
  "auto_impl",
  "derive_more",
@@ -7922,6 +6714,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7935,6 +6728,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7976,7 +6770,6 @@ dependencies = [
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
- "reth-ethereum-cli",
  "reth-ethereum-primitives",
  "reth-etl",
  "reth-evm",
@@ -8008,7 +6801,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "tempfile",
  "tokio",
  "tokio-stream",
  "toml",
@@ -8020,6 +6812,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8029,6 +6822,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8036,12 +6830,10 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "rand 0.9.2",
  "reth-fs-util",
  "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
- "snmalloc-rs",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tracy-client",
@@ -8050,6 +6842,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8060,41 +6853,34 @@ dependencies = [
  "bytes",
  "modular-bitfield",
  "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
  "reth-codecs-derive",
  "reth-zstd-compressors",
- "rstest",
  "serde",
- "serde_json",
- "test-fuzz",
  "visibility",
 ]
 
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "proc-macro2",
  "quote",
- "similar-asserts",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "reth-config"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-primitives",
  "eyre",
  "humantime-serde",
- "reth-network-peers",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
  "serde",
- "tempfile",
  "toml",
  "url",
 ]
@@ -8102,6 +6888,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8114,20 +6901,19 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
- "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
- "reth-ethereum-primitives",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8153,31 +6939,23 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-consensus",
  "alloy-primitives",
- "arbitrary",
- "assert_matches",
- "codspeed-criterion-compat",
  "derive_more",
  "eyre",
  "metrics",
  "page_size",
  "parking_lot",
- "proptest",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
- "reth-primitives-traits",
- "reth-prune-types",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
  "rustc-hash",
- "serde",
- "serde_json",
  "strum 0.27.2",
  "sysinfo",
  "tempfile",
@@ -8187,6 +6965,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8198,12 +6977,10 @@ dependencies = [
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "proptest-arbitrary-interop",
- "rand 0.9.2",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
@@ -8211,12 +6988,12 @@ dependencies = [
  "reth-trie-common",
  "roaring",
  "serde",
- "test-fuzz",
 ]
 
 [[package]]
 name = "reth-db-common"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8226,7 +7003,6 @@ dependencies = [
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
- "reth-db",
  "reth-db-api",
  "reth-etl",
  "reth-execution-errors",
@@ -8247,14 +7023,13 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "proptest",
- "proptest-arbitrary-interop",
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
@@ -8263,10 +7038,10 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "assert_matches",
  "discv5",
  "enr",
  "itertools 0.14.0",
@@ -8276,7 +7051,6 @@ dependencies = [
  "reth-net-banlist",
  "reth-net-nat",
  "reth-network-peers",
- "reth-tracing",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8289,6 +7063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8298,13 +7073,11 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.8.5",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "reth-tracing",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
  "tokio",
@@ -8314,21 +7087,17 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-chains",
  "alloy-primitives",
- "alloy-rlp",
  "data-encoding",
  "enr",
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "rand 0.9.2",
- "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-tokio-util",
- "reth-tracing",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8342,21 +7111,19 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "assert_matches",
  "async-compression",
  "futures",
  "futures-util",
  "itertools 0.14.0",
  "metrics",
  "pin-project",
- "rand 0.9.2",
  "rayon",
- "reth-chainspec",
  "reth-config",
  "reth-consensus",
  "reth-ethereum-primitives",
@@ -8368,7 +7135,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
- "reth-tracing",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -8380,6 +7146,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8437,6 +7204,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8464,6 +7232,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8474,7 +7243,7 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
- "reth-optimism-chainspec",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -8488,6 +7257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8512,37 +7282,30 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-eips",
  "futures",
  "pin-project",
  "reth-chainspec",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
- "reth-ethereum-consensus",
- "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-evm-ethereum",
- "reth-exex-types",
  "reth-network-p2p",
- "reth-node-ethereum",
  "reth-node-types",
  "reth-payload-builder",
- "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
  "reth-trie-db",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8551,40 +7314,26 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "assert_matches",
- "codspeed-criterion-compat",
  "crossbeam-channel",
  "dashmap 6.1.0",
  "derive_more",
- "eyre",
  "futures",
  "metrics",
- "metrics-util",
  "mini-moka",
  "moka",
  "parking_lot",
- "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
- "reth-db-common",
- "reth-e2e-test-utils",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-consensus",
- "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-execution-types",
- "reth-exex-types",
  "reth-metrics",
  "reth-network-p2p",
- "reth-node-ethereum",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-primitives-traits",
@@ -8596,7 +7345,6 @@ dependencies = [
  "reth-stages-api",
  "reth-static-file",
  "reth-tasks",
- "reth-testing-utils",
  "reth-tracing",
  "reth-trie",
  "reth-trie-common",
@@ -8606,9 +7354,7 @@ dependencies = [
  "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
- "revm-state",
  "schnellru",
- "serde_json",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -8618,6 +7364,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8645,6 +7392,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8652,48 +7400,36 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "eyre",
- "rand 0.9.2",
- "reqwest",
- "reth-era-downloader",
- "reth-ethereum-primitives",
  "snap",
- "tempfile",
- "test-case",
  "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
- "futures",
  "futures-util",
  "reqwest",
  "reth-era",
  "reth-fs-util",
  "sha2",
- "tempfile",
- "test-case",
  "tokio",
 ]
 
 [[package]]
 name = "reth-era-utils"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
- "bytes",
  "eyre",
  "futures-util",
- "reqwest",
  "reth-db-api",
- "reth-db-common",
  "reth-era",
  "reth-era-downloader",
  "reth-etl",
@@ -8702,15 +7438,14 @@ dependencies = [
  "reth-provider",
  "reth-stages-types",
  "reth-storage-api",
- "tempfile",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "reth-errors"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8721,22 +7456,16 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "async-stream",
  "bytes",
  "derive_more",
  "futures",
  "pin-project",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
@@ -8744,11 +7473,8 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "reth-primitives-traits",
- "reth-tracing",
- "secp256k1 0.30.0",
  "serde",
  "snap",
- "test-fuzz",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -8759,11 +7485,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -8772,7 +7498,6 @@ dependencies = [
  "derive_more",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.2",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -8782,70 +7507,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-ethereum"
-version = "1.10.1"
-dependencies = [
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "reth-chainspec",
- "reth-cli-util",
- "reth-codecs",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-engine-local",
- "reth-eth-wire",
- "reth-ethereum-cli",
- "reth-ethereum-consensus",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-exex",
- "reth-network",
- "reth-network-api",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-primitives-traits",
- "reth-provider",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-eth-types",
- "reth-storage-api",
- "reth-tasks",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
-]
-
-[[package]]
-name = "reth-ethereum-cli"
-version = "1.10.1"
-dependencies = [
- "clap",
- "eyre",
- "reth-chainspec",
- "reth-cli",
- "reth-cli-commands",
- "reth-cli-runner",
- "reth-db",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-metrics",
- "reth-rpc-server-types",
- "reth-tracing",
- "tempfile",
- "tracing",
-]
-
-[[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8853,7 +7517,6 @@ dependencies = [
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
- "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-primitives-traits",
  "tracing",
@@ -8862,6 +7525,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8872,7 +7536,6 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "serde_json",
  "sha2",
  "thiserror 2.0.18",
 ]
@@ -8880,6 +7543,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8893,6 +7557,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8921,6 +7586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8929,27 +7595,19 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "bincode 1.3.3",
- "derive_more",
  "modular-bitfield",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
- "secp256k1 0.30.0",
  "serde",
- "serde_json",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-primitives",
  "rayon",
  "reth-db-api",
  "tempfile",
@@ -8958,6 +7616,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8968,8 +7627,6 @@ dependencies = [
  "futures-util",
  "metrics",
  "rayon",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-execution-types",
  "reth-metrics",
@@ -8983,11 +7640,11 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -8999,14 +7656,13 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-storage-errors",
- "reth-testing-utils",
  "revm",
- "secp256k1 0.30.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9019,15 +7675,13 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "arbitrary",
- "bincode 1.3.3",
  "derive_more",
- "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -9039,24 +7693,21 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-genesis",
  "alloy-primitives",
  "eyre",
  "futures",
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
- "reth-db-common",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-exex-types",
  "reth-fs-util",
  "reth-metrics",
@@ -9069,12 +7720,8 @@ dependencies = [
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
- "reth-testing-utils",
  "reth-tracing",
- "reth-trie-common",
  "rmp-serde",
- "secp256k1 0.30.0",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -9084,6 +7731,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9115,14 +7763,11 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "arbitrary",
- "bincode 1.3.3",
- "rand 0.9.2",
  "reth-chain-state",
- "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-primitives-traits",
  "serde",
@@ -9132,6 +7777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "serde",
  "serde_json",
@@ -9141,9 +7787,9 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -9151,16 +7797,12 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "pretty_assertions",
- "reth-chainspec",
  "reth-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
- "reth-testing-utils",
  "reth-tracing",
  "reth-trie",
  "revm",
@@ -9168,12 +7810,12 @@ dependencies = [
  "revm-database",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
 name = "reth-ipc"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bytes",
  "futures",
@@ -9181,9 +7823,6 @@ dependencies = [
  "interprocess",
  "jsonrpsee",
  "pin-project",
- "rand 0.9.2",
- "reth-tracing",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -9196,17 +7835,15 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
- "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "derive_more",
  "parking_lot",
- "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
- "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -9214,6 +7851,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9222,6 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "futures",
  "metrics",
@@ -9233,6 +7872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9241,11 +7881,11 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "futures-util",
  "if-addrs",
  "reqwest",
- "reth-tracing",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -9255,15 +7895,14 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "codspeed-criterion-compat",
  "derive_more",
  "discv5",
  "enr",
@@ -9288,17 +7927,14 @@ dependencies = [
  "reth-fs-util",
  "reth-metrics",
  "reth-net-banlist",
- "reth-network",
  "reth-network-api",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
  "reth-primitives-traits",
- "reth-provider",
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
- "reth-tracing",
  "reth-transaction-pool",
  "rustc-hash",
  "schnellru",
@@ -9310,12 +7946,12 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "reth-network-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9340,6 +7976,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9362,14 +7999,12 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "enr",
- "rand 0.8.5",
- "rand 0.9.2",
  "secp256k1 0.30.0",
- "serde_json",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -9379,6 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9392,16 +8028,15 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode",
  "derive_more",
  "lz4_flex",
  "memmap2",
- "rand 0.9.2",
  "reth-fs-util",
  "serde",
- "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -9410,6 +8045,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9433,6 +8069,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9462,9 +8099,7 @@ dependencies = [
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
- "reth-ethereum-engine-primitives",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-exex",
  "reth-fs-util",
  "reth-invalid-block-hooks",
@@ -9473,7 +8108,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
- "reth-node-ethereum",
  "reth-node-ethstats",
  "reth-node-events",
  "reth-node-metrics",
@@ -9496,7 +8130,6 @@ dependencies = [
  "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
- "tempfile",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9505,6 +8138,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9517,7 +8151,6 @@ dependencies = [
  "futures",
  "humantime",
  "ipnet",
- "proptest",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
@@ -9551,7 +8184,6 @@ dependencies = [
  "shellexpand",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "tokio",
  "toml",
  "tracing",
  "url",
@@ -9562,27 +8194,14 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-consensus",
- "alloy-contract",
  "alloy-eips",
- "alloy-genesis",
  "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-signer",
- "alloy-sol-types",
  "eyre",
- "futures",
- "jsonrpsee-core",
- "rand 0.9.2",
  "reth-chainspec",
- "reth-db",
- "reth-e2e-test-utils",
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
@@ -9591,11 +8210,9 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-exex",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
- "reth-node-core",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
@@ -9606,22 +8223,16 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-stages-types",
- "reth-tasks",
- "reth-testing-utils",
  "reth-tracing",
  "reth-transaction-pool",
  "revm",
- "serde",
- "serde_json",
- "similar-asserts",
- "tempfile",
  "tokio",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9645,6 +8256,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9668,6 +8280,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bytes",
  "eyre",
@@ -9686,7 +8299,6 @@ dependencies = [
  "reth-fs-util",
  "reth-metrics",
  "reth-tasks",
- "socket2 0.5.10",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9697,6 +8309,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9724,12 +8337,12 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
- "reth-optimism-chainspec",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-cli",
- "reth-optimism-consensus",
- "reth-optimism-evm",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-rpc",
  "reth-primitives-traits",
  "reth-provider",
@@ -9764,8 +8377,36 @@ dependencies = [
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-optimism-forks",
- "reth-optimism-primitives",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-primitives-traits",
+ "serde",
+ "serde_json",
+ "tar-no-std",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-optimism-chainspec"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "derive_more",
+ "miniz_oxide",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+ "paste",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "serde",
  "serde_json",
@@ -9802,11 +8443,11 @@ dependencies = [
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-optimism-chainspec",
- "reth-optimism-consensus",
- "reth-optimism-evm",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-trie",
  "reth-primitives-traits",
  "reth-provider",
@@ -9838,16 +8479,41 @@ dependencies = [
  "reth-consensus-common",
  "reth-db-common",
  "reth-execution-types",
- "reth-optimism-chainspec",
- "reth-optimism-forks",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
+ "revm",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-consensus"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-trie",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-execution-types",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
  "reth-trie-common",
  "revm",
  "thiserror 2.0.18",
@@ -9871,12 +8537,40 @@ dependencies = [
  "reth-evm",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-optimism-chainspec",
- "reth-optimism-consensus",
- "reth-optimism-forks",
- "reth-optimism-primitives",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-eth-api",
+ "reth-storage-errors",
+ "revm",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-optimism-evm"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-evm",
+ "alloy-primitives",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
+ "op-revm",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-primitives-traits",
  "reth-rpc-eth-api",
  "reth-storage-errors",
  "revm",
@@ -9900,7 +8594,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-types",
- "reth-optimism-chainspec",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
  "reth-optimism-trie",
  "reth-primitives-traits",
@@ -9932,8 +8626,8 @@ dependencies = [
  "reth-evm",
  "reth-execution-types",
  "reth-metrics",
- "reth-optimism-payload-builder",
- "reth-optimism-primitives",
+ "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-revm",
@@ -9950,8 +8644,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-flashblocks"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "brotli",
+ "derive_more",
+ "eyre",
+ "futures-util",
+ "metrics",
+ "op-alloy-rpc-types-engine",
+ "reth-chain-state",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-rpc-eth-types",
+ "reth-storage-api",
+ "reth-tasks",
+ "ringbuffer",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "reth-optimism-forks"
 version = "1.10.1"
+dependencies = [
+ "alloy-op-hardforks",
+ "alloy-primitives",
+ "once_cell",
+ "reth-ethereum-forks",
+]
+
+[[package]]
+name = "reth-optimism-forks"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9988,16 +8730,16 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
- "reth-optimism-chainspec",
- "reth-optimism-consensus",
- "reth-optimism-evm",
- "reth-optimism-forks",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-consensus 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-node",
- "reth-optimism-payload-builder",
- "reth-optimism-primitives",
+ "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-rpc",
- "reth-optimism-storage",
- "reth-optimism-txpool",
+ "reth-optimism-storage 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-payload-builder",
  "reth-payload-util",
  "reth-primitives-traits",
@@ -10040,10 +8782,50 @@ dependencies = [
  "reth-chainspec",
  "reth-evm",
  "reth-execution-types",
- "reth-optimism-evm",
- "reth-optimism-forks",
- "reth-optimism-primitives",
- "reth-optimism-txpool",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-payload-builder",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-payload-util",
+ "reth-payload-validator",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-storage-api",
+ "reth-transaction-pool",
+ "revm",
+ "serde",
+ "sha2",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-payload-builder"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
+ "alloy-rpc-types-engine",
+ "derive_more",
+ "either",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types-engine",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -10069,7 +8851,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "modular-bitfield",
  "op-alloy-consensus",
@@ -10084,6 +8866,21 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-optimism-primitives"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "op-alloy-consensus",
+ "reth-primitives-traits",
+ "serde",
  "serde_with",
 ]
 
@@ -10126,14 +8923,14 @@ dependencies = [
  "reth-metrics",
  "reth-node-api",
  "reth-node-builder",
- "reth-optimism-chainspec",
- "reth-optimism-evm",
- "reth-optimism-flashblocks",
- "reth-optimism-forks",
- "reth-optimism-payload-builder",
- "reth-optimism-primitives",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-flashblocks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-payload-builder 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-optimism-trie",
- "reth-optimism-txpool",
+ "reth-optimism-txpool 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-payload-util",
  "reth-primitives-traits",
  "reth-provider",
@@ -10164,9 +8961,19 @@ version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-storage-api",
+]
+
+[[package]]
+name = "reth-optimism-storage"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-storage-api",
 ]
 
@@ -10179,7 +8986,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "auto_impl",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "derive_more",
  "eyre",
@@ -10238,10 +9045,10 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-metrics",
- "reth-optimism-chainspec",
- "reth-optimism-evm",
- "reth-optimism-forks",
- "reth-optimism-primitives",
+ "reth-optimism-chainspec 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-api",
@@ -10253,8 +9060,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-txpool"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "c-kzg",
+ "derive_more",
+ "futures-util",
+ "metrics",
+ "op-alloy-consensus",
+ "op-alloy-flz",
+ "op-alloy-rpc-types",
+ "op-revm",
+ "parking_lot",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-metrics",
+ "reth-optimism-evm 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-forks 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-transaction-pool",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-payload-builder"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10275,6 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10286,12 +9131,12 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "assert_matches",
  "auto_impl",
  "either",
  "op-alloy-rpc-types-engine",
@@ -10309,6 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10318,6 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10327,19 +9174,10 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "c-kzg",
- "codspeed-criterion-compat",
  "once_cell",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-codecs",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -10349,6 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10359,7 +9198,6 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "auto_impl",
- "bincode 1.3.3",
  "byteorder",
  "bytes",
  "derive_more",
@@ -10368,17 +9206,13 @@ dependencies = [
  "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
  "rayon",
- "reth-chainspec",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "serde_json",
  "serde_with",
  "thiserror 2.0.18",
 ]
@@ -10386,19 +9220,18 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "assert_matches",
  "dashmap 6.1.0",
  "eyre",
  "itertools 0.14.0",
  "metrics",
  "notify",
  "parking_lot",
- "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -10418,16 +9251,12 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
- "reth-testing-utils",
- "reth-tracing",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
- "revm-database-interface",
  "revm-state",
  "rocksdb",
  "strum 0.27.2",
- "tempfile",
  "tokio",
  "tracing",
 ]
@@ -10435,16 +9264,15 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "assert_matches",
  "itertools 0.14.0",
  "metrics",
  "rayon",
  "reth-config",
- "reth-db",
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
@@ -10452,12 +9280,9 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
- "reth-stages",
  "reth-stages-types",
  "reth-static-file-types",
- "reth-testing-utils",
  "reth-tokio-util",
- "reth-tracing",
  "rustc-hash",
  "thiserror 2.0.18",
  "tokio",
@@ -10465,87 +9290,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-prune-db"
-version = "1.10.1"
-
-[[package]]
 name = "reth-prune-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "assert_matches",
  "derive_more",
  "modular-bitfield",
- "proptest",
- "proptest-arbitrary-interop",
  "reth-codecs",
  "serde",
- "serde_json",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "toml",
-]
-
-[[package]]
-name = "reth-ress-protocol"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "futures",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-eth-wire",
- "reth-ethereum-primitives",
- "reth-network",
- "reth-network-api",
- "reth-provider",
- "reth-ress-protocol",
- "reth-storage-errors",
- "reth-tracing",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-ress-provider"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "eyre",
- "futures",
- "parking_lot",
- "reth-chain-state",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-node-api",
- "reth-primitives-traits",
- "reth-ress-protocol",
- "reth-revm",
- "reth-storage-api",
- "reth-tasks",
- "reth-tokio-util",
- "reth-trie",
- "schnellru",
- "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "reth-revm"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-consensus",
  "alloy-primitives",
- "reth-ethereum-forks",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -10556,6 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10592,12 +9357,10 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
- "reth-db-api",
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-engine-primitives",
@@ -10611,7 +9374,6 @@ dependencies = [
  "reth-network-types",
  "reth-node-api",
  "reth-primitives-traits",
- "reth-provider",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-convert",
@@ -10621,7 +9383,6 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
- "reth-testing-utils",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",
@@ -10641,6 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10665,40 +9427,15 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-trie-common",
  "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "reth-rpc-api-testing-util"
-version = "1.10.1"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "futures",
- "jsonrpsee",
- "jsonrpsee-http-client",
- "reth-ethereum-primitives",
- "reth-rpc-api",
- "reth-rpc-eth-api",
- "serde_json",
- "similar-asserts",
- "tokio",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-eips",
  "alloy-network",
- "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "clap",
  "dyn-clone",
  "http",
  "jsonrpsee",
@@ -10708,22 +9445,14 @@ dependencies = [
  "reth-chainspec",
  "reth-consensus",
  "reth-engine-primitives",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-ipc",
  "reth-metrics",
  "reth-network-api",
- "reth-network-peers",
  "reth-node-core",
- "reth-node-ethereum",
- "reth-payload-builder",
  "reth-primitives-traits",
- "reth-provider",
  "reth-rpc",
  "reth-rpc-api",
- "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
@@ -10731,10 +9460,8 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
- "reth-tracing",
  "reth-transaction-pool",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -10746,6 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10762,62 +9490,35 @@ dependencies = [
  "op-alloy-rpc-types",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-optimism-primitives",
+ "reth-optimism-primitives 1.10.1 (git+https://github.com/paradigmxyz/reth?tag=v1.10.1)",
  "reth-primitives-traits",
  "reth-storage-api",
- "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-rpc-e2e-tests"
-version = "1.10.1"
-dependencies = [
- "alloy-genesis",
- "alloy-rpc-types-engine",
- "eyre",
- "futures-util",
- "jsonrpsee",
- "reth-chainspec",
- "reth-e2e-test-utils",
- "reth-node-api",
- "reth-node-ethereum",
- "reth-rpc-api",
- "reth-tracing",
- "serde_json",
- "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
- "assert_matches",
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-metrics",
  "reth-network-api",
- "reth-node-ethereum",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
- "reth-provider",
  "reth-rpc-api",
  "reth-storage-api",
  "reth-tasks",
- "reth-testing-utils",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.18",
@@ -10828,6 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10871,6 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10908,7 +9611,6 @@ dependencies = [
  "revm-inspectors",
  "schnellru",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -10919,15 +9621,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
- "http-body-util",
- "jsonrpsee",
  "jsonrpsee-http-client",
  "pin-project",
- "reqwest",
- "tokio",
  "tower",
  "tower-http",
  "tracing",
@@ -10936,6 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10951,20 +9651,16 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
- "assert_matches",
- "bincode 1.3.3",
- "codspeed-criterion-compat",
+ "bincode",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
- "paste",
- "rand 0.9.2",
  "rayon",
  "reqwest",
  "reth-chainspec",
@@ -10973,27 +9669,22 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-db-api",
- "reth-downloaders",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
- "reth-ethereum-consensus",
  "reth-ethereum-primitives",
  "reth-etl",
  "reth-evm",
- "reth-evm-ethereum",
  "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
- "reth-network-peers",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-prune-types",
  "reth-revm",
  "reth-stages-api",
- "reth-static-file",
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11009,18 +9700,15 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "aquamarine",
- "assert_matches",
  "auto_impl",
  "futures-util",
  "metrics",
- "reth-chainspec",
  "reth-consensus",
- "reth-db",
- "reth-db-api",
  "reth-errors",
  "reth-metrics",
  "reth-network-p2p",
@@ -11030,64 +9718,32 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
- "reth-testing-utils",
  "reth-tokio-util",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-stages-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.9.2",
  "reth-codecs",
  "reth-trie-common",
  "serde",
 ]
 
 [[package]]
-name = "reth-stateless"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-debug",
- "alloy-trie",
- "itertools 0.14.0",
- "k256",
- "reth-chainspec",
- "reth-consensus",
- "reth-errors",
- "reth-ethereum-consensus",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-primitives-traits",
- "reth-revm",
- "reth-trie-common",
- "reth-trie-sparse",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "reth-static-file"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
- "assert_matches",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -11095,34 +9751,30 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
- "reth-stages",
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-errors",
- "reth-testing-utils",
  "reth-tokio-util",
- "tempfile",
  "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
  "fixed-map",
- "insta",
- "reth-nippy-jar",
  "serde",
- "serde_json",
  "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-storage-api"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11146,6 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11160,37 +9813,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-rpc-provider"
-version = "1.10.1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-rpc-types-engine",
- "parking_lot",
- "reth-chainspec",
- "reth-db-api",
- "reth-errors",
- "reth-execution-types",
- "reth-node-types",
- "reth-primitives",
- "reth-provider",
- "reth-prune-types",
- "reth-rpc-convert",
- "reth-stages-types",
- "reth-storage-api",
- "reth-trie",
- "revm",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-tasks"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11208,12 +9833,12 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-rlp",
  "rand 0.8.5",
  "rand 0.9.2",
  "reth-ethereum-primitives",
@@ -11224,6 +9849,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11233,6 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "clap",
  "eyre",
@@ -11251,6 +9878,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "clap",
  "eyre",
@@ -11268,17 +9896,15 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
- "assert_matches",
  "auto_impl",
  "bitflags 2.10.0",
- "codspeed-criterion-compat",
- "futures",
  "futures-util",
  "metrics",
  "parking_lot",
@@ -11295,10 +9921,8 @@ dependencies = [
  "reth-fs-util",
  "reth-metrics",
  "reth-primitives-traits",
- "reth-provider",
  "reth-storage-api",
  "reth-tasks",
- "reth-tracing",
  "revm-interpreter",
  "revm-primitives",
  "rustc-hash",
@@ -11306,7 +9930,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -11316,33 +9939,25 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "assert_matches",
  "auto_impl",
- "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "pretty_assertions",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.9.2",
- "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
- "reth-tracing",
  "reth-trie-common",
  "reth-trie-sparse",
  "revm-database",
- "revm-state",
  "tracing",
  "triehash",
 ]
@@ -11350,9 +9965,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
- "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
@@ -11360,81 +9975,59 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "arrayvec",
- "bincode 1.3.3",
  "bytes",
- "codspeed-criterion-compat",
  "derive_more",
  "hash-db",
  "itertools 0.14.0",
  "nybbles",
  "plain_hasher",
- "proptest",
- "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
  "revm-database",
- "revm-state",
  "serde",
- "serde_json",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-trie-db"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-consensus",
  "alloy-primitives",
- "alloy-rlp",
  "metrics",
  "parking_lot",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-chainspec",
- "reth-db",
  "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
- "reth-provider",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm",
- "revm-database",
- "serde_json",
- "similar-asserts",
  "tracing",
- "triehash",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "codspeed-criterion-compat",
  "crossbeam-channel",
  "dashmap 6.1.0",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.9.2",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
- "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "reth-trie-db",
  "reth-trie-sparse",
  "thiserror 2.0.18",
  "tokio",
@@ -11444,32 +10037,18 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "arbitrary",
- "assert_matches",
  "auto_impl",
- "codspeed-criterion-compat",
- "itertools 0.14.0",
  "metrics",
- "pretty_assertions",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
- "reth-provider",
- "reth-storage-api",
- "reth-testing-utils",
- "reth-tracing",
- "reth-trie",
  "reth-trie-common",
- "reth-trie-db",
  "smallvec",
  "tracing",
 ]
@@ -11477,28 +10056,16 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "arbitrary",
- "assert_matches",
- "itertools 0.14.0",
  "metrics",
- "pretty_assertions",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
- "reth-primitives-traits",
- "reth-provider",
- "reth-tracing",
- "reth-trie",
  "reth-trie-common",
- "reth-trie-db",
  "reth-trie-sparse",
  "smallvec",
  "tracing",
@@ -11507,6 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "zstd",
 ]
@@ -12303,15 +10871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_combinators"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de5fb30ae2918667d3cee99ef4b112f1f7ca0a6c58fa349d7d9e76035c72f8b"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12343,17 +10902,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -12558,27 +11106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console",
- "serde",
- "similar",
-]
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12647,25 +11174,6 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
-name = "snmalloc-rs"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
-dependencies = [
- "snmalloc-sys",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
-dependencies = [
- "cc",
- "cmake",
-]
 
 [[package]]
 name = "socket2"
@@ -12893,7 +11401,7 @@ version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
@@ -12937,58 +11445,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "test-case-core",
-]
-
-[[package]]
-name = "test-fuzz"
-version = "7.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e5c77910b1d5b469a342be541cf44933f0ad2c4b8d5acb32ee46697fd60546"
-dependencies = [
- "serde",
- "serde_combinators",
- "test-fuzz-internal",
- "test-fuzz-macro",
- "test-fuzz-runtime",
-]
-
-[[package]]
-name = "test-fuzz-internal"
-version = "7.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25f2f0ee315b130411a98570dd128dfe344bfaa0a28bf33d38f4a1fe85f39b"
-dependencies = [
- "bincode 2.0.1",
- "cargo_metadata 0.19.2",
- "serde",
-]
-
-[[package]]
-name = "test-fuzz-macro"
-version = "7.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c03ba0a9e3e4032f94d71c85e149af147843c6f212e4ca4383542d606b04a6"
-dependencies = [
- "darling 0.21.3",
- "heck",
- "itertools 0.14.0",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "test-fuzz-runtime"
-version = "7.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4ac481aa983d386e857a7be0006c2f0ef26e0c5326bbc7262f73c2891b91d"
-dependencies = [
- "hex",
- "num-traits",
- "serde",
- "sha1",
- "test-fuzz-internal",
 ]
 
 [[package]]
@@ -13138,16 +11594,6 @@ dependencies = [
  "displaydoc",
  "serde_core",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -13461,16 +11907,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -13800,12 +12236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13913,12 +12343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "visibility"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13939,12 +12363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13962,12 +12380,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,25 +9,18 @@ exclude = [".github/"]
 
 [workspace]
 members = [
+    # Include upstream reth binary to support `make build` and standard CI workflows.
+    # This ensures that `cargo build --bin reth` can resolve the target.
+    "bin/reth",
     "crates/optimism/bin/op-reth",
     "crates/optimism/bin/proof-bench",
-    "crates/optimism/chainspec",
     "crates/optimism/cli",
-    "crates/optimism/consensus",
-    "crates/optimism/evm/",
     "crates/optimism/exex/",
-    "crates/optimism/flashblocks/",
-    "crates/optimism/hardforks/",
     "crates/optimism/node/",
-    "crates/optimism/payload/",
-    "crates/optimism/primitives/",
-    "crates/optimism/reth/",
     "crates/optimism/rpc/",
-    "crates/optimism/storage",
     "crates/optimism/trie",
-    "crates/optimism/txpool/",
 ]
-default-members = ["crates/optimism/bin/op-reth"]
+default-members = ["bin/reth", "crates/optimism/bin/op-reth"]
 exclude = ["docs/cli"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,69 +9,6 @@ exclude = [".github/"]
 
 [workspace]
 members = [
-    "bin/reth-bench/",
-    "bin/reth-bench-compare/",
-    "bin/reth/",
-    "crates/storage/rpc-provider/",
-    "crates/chain-state/",
-    "crates/chainspec/",
-    "crates/cli/cli/",
-    "crates/cli/commands/",
-    "crates/cli/runner/",
-    "crates/cli/util/",
-    "crates/config/",
-    "crates/consensus/common/",
-    "crates/consensus/consensus/",
-    "crates/consensus/debug-client/",
-    "crates/e2e-test-utils/",
-    "crates/engine/invalid-block-hooks/",
-    "crates/engine/local",
-    "crates/engine/primitives/",
-    "crates/engine/service",
-    "crates/engine/tree/",
-    "crates/engine/util/",
-    "crates/era",
-    "crates/era-downloader",
-    "crates/era-utils",
-    "crates/errors/",
-    "crates/ethereum/hardforks/",
-    "crates/ethereum/cli/",
-    "crates/ethereum/consensus/",
-    "crates/ethereum/engine-primitives/",
-    "crates/ethereum/evm",
-    "crates/ethereum/node",
-    "crates/ethereum/payload/",
-    "crates/ethereum/primitives/",
-    "crates/ethereum/reth/",
-    "crates/etl/",
-    "crates/evm/evm",
-    "crates/evm/execution-errors",
-    "crates/evm/execution-types",
-    "crates/exex/exex/",
-    "crates/exex/test-utils/",
-    "crates/exex/types/",
-    "crates/metrics/",
-    "crates/net/banlist/",
-    "crates/net/discv4/",
-    "crates/net/discv5/",
-    "crates/net/dns/",
-    "crates/net/downloaders/",
-    "crates/net/ecies/",
-    "crates/net/eth-wire-types",
-    "crates/net/eth-wire/",
-    "crates/net/nat/",
-    "crates/net/network-api/",
-    "crates/net/network-types/",
-    "crates/net/network/",
-    "crates/net/p2p/",
-    "crates/net/peers/",
-    "crates/node/api/",
-    "crates/node/builder/",
-    "crates/node/core/",
-    "crates/node/ethstats",
-    "crates/node/events/",
-    "crates/node/metrics",
-    "crates/node/types",
     "crates/optimism/bin/op-reth",
     "crates/optimism/bin/proof-bench",
     "crates/optimism/chainspec",
@@ -89,100 +26,8 @@ members = [
     "crates/optimism/storage",
     "crates/optimism/trie",
     "crates/optimism/txpool/",
-    "crates/payload/basic/",
-    "crates/payload/builder/",
-    "crates/payload/builder-primitives/",
-    "crates/payload/primitives/",
-    "crates/payload/validator/",
-    "crates/payload/util/",
-    "crates/primitives-traits/",
-    "crates/primitives/",
-    "crates/prune/db",
-    "crates/prune/prune",
-    "crates/prune/types",
-    "crates/ress/protocol",
-    "crates/ress/provider",
-    "crates/revm/",
-    "crates/rpc/ipc/",
-    "crates/rpc/rpc-api/",
-    "crates/rpc/rpc-builder/",
-    "crates/rpc/rpc-engine-api/",
-    "crates/rpc/rpc-eth-api/",
-    "crates/rpc/rpc-eth-types/",
-    "crates/rpc/rpc-layer",
-    "crates/rpc/rpc-server-types/",
-    "crates/rpc/rpc-testing-util/",
-    "crates/rpc/rpc-e2e-tests/",
-    "crates/rpc/rpc-convert/",
-    "crates/rpc/rpc/",
-    "crates/stages/api/",
-    "crates/stages/stages/",
-    "crates/stages/types/",
-    "crates/stateless",
-    "crates/static-file/static-file",
-    "crates/static-file/types/",
-    "crates/storage/codecs/",
-    "crates/storage/codecs/derive/",
-    "crates/storage/db-api/",
-    "crates/storage/db-common",
-    "crates/storage/db-models/",
-    "crates/storage/db/",
-    "crates/storage/errors/",
-    "crates/storage/libmdbx-rs/",
-    "crates/storage/libmdbx-rs/mdbx-sys/",
-    "crates/storage/nippy-jar/",
-    "crates/storage/provider/",
-    "crates/storage/storage-api/",
-    "crates/storage/zstd-compressors/",
-    "crates/tasks/",
-    "crates/tokio-util/",
-    "crates/tracing/",
-    "crates/transaction-pool/",
-    "crates/trie/common",
-    "crates/trie/db",
-    "crates/trie/parallel/",
-    "crates/trie/sparse",
-    "crates/trie/sparse-parallel/",
-    "crates/trie/trie",
-    "examples/beacon-api-sidecar-fetcher/",
-    "examples/beacon-api-sse/",
-    "examples/bsc-p2p",
-    "examples/custom-dev-node/",
-    "examples/custom-node/",
-    "examples/custom-engine-types/",
-    "examples/custom-evm/",
-    "examples/custom-hardforks/",
-    "examples/custom-inspector/",
-    "examples/custom-node-components/",
-    "examples/custom-payload-builder/",
-    "examples/custom-rlpx-subprotocol",
-    "examples/custom-rpc-middleware",
-    "examples/custom-node",
-    "examples/db-access",
-    "examples/engine-api-access",
-    "examples/exex-hello-world",
-    "examples/exex-subscription",
-    "examples/exex-test",
-    "examples/full-contract-state",
-    "examples/manual-p2p/",
-    "examples/network-txpool/",
-    "examples/network/",
-    "examples/network-proxy/",
-    "examples/node-builder-api/",
-    "examples/node-custom-rpc/",
-    "examples/node-event-hooks/",
-    "examples/op-db-access/",
-    "examples/polygon-p2p/",
-    "examples/rpc-db/",
-    "examples/precompile-cache/",
-    "examples/txpool-tracing/",
-    "examples/custom-beacon-withdrawals",
-    "testing/ef-tests/",
-    "testing/testing-utils",
-    "testing/runner",
-    "crates/tracing-otlp",
 ]
-default-members = ["bin/reth"]
+default-members = ["crates/optimism/bin/op-reth"]
 exclude = ["docs/cli"]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
@@ -341,142 +186,142 @@ incremental = false
 [workspace.dependencies]
 # reth
 op-reth = { path = "crates/optimism/bin/op-reth" }
-reth = { path = "bin/reth" }
-reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }
-reth-basic-payload-builder = { path = "crates/payload/basic" }
-reth-bench = { path = "bin/reth-bench" }
-reth-bench-compare = { path = "bin/reth-bench-compare" }
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-storage-rpc-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-bench = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-bench-compare = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
 op-reth-proof-bench = { path = "crates/optimism/bin/proof-bench" }
-reth-chain-state = { path = "crates/chain-state" }
-reth-chainspec = { path = "crates/chainspec", default-features = false }
-reth-cli = { path = "crates/cli/cli" }
-reth-cli-commands = { path = "crates/cli/commands" }
-reth-cli-runner = { path = "crates/cli/runner" }
-reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { path = "crates/storage/codecs" }
-reth-codecs-derive = { path = "crates/storage/codecs/derive" }
-reth-config = { path = "crates/config", default-features = false }
-reth-consensus = { path = "crates/consensus/consensus", default-features = false }
-reth-consensus-common = { path = "crates/consensus/common", default-features = false }
-reth-consensus-debug-client = { path = "crates/consensus/debug-client" }
-reth-db = { path = "crates/storage/db", default-features = false }
-reth-db-api = { path = "crates/storage/db-api" }
-reth-db-common = { path = "crates/storage/db-common" }
-reth-db-models = { path = "crates/storage/db-models", default-features = false }
-reth-discv4 = { path = "crates/net/discv4" }
-reth-discv5 = { path = "crates/net/discv5" }
-reth-dns-discovery = { path = "crates/net/dns" }
-reth-downloaders = { path = "crates/net/downloaders" }
-reth-e2e-test-utils = { path = "crates/e2e-test-utils" }
-reth-ecies = { path = "crates/net/ecies" }
-reth-engine-local = { path = "crates/engine/local" }
-reth-engine-primitives = { path = "crates/engine/primitives", default-features = false }
-reth-engine-tree = { path = "crates/engine/tree" }
-reth-engine-service = { path = "crates/engine/service" }
-reth-engine-util = { path = "crates/engine/util" }
-reth-era = { path = "crates/era" }
-reth-era-downloader = { path = "crates/era-downloader" }
-reth-era-utils = { path = "crates/era-utils" }
-reth-errors = { path = "crates/errors" }
-reth-eth-wire = { path = "crates/net/eth-wire" }
-reth-eth-wire-types = { path = "crates/net/eth-wire-types" }
-reth-ethereum-payload-builder = { path = "crates/ethereum/payload" }
-reth-ethereum-cli = { path = "crates/ethereum/cli", default-features = false }
-reth-ethereum-consensus = { path = "crates/ethereum/consensus", default-features = false }
-reth-ethereum-engine-primitives = { path = "crates/ethereum/engine-primitives", default-features = false }
-reth-ethereum-forks = { path = "crates/ethereum/hardforks", default-features = false }
-reth-ethereum-primitives = { path = "crates/ethereum/primitives", default-features = false }
-reth-ethereum = { path = "crates/ethereum/reth" }
-reth-etl = { path = "crates/etl" }
-reth-evm = { path = "crates/evm/evm", default-features = false }
-reth-evm-ethereum = { path = "crates/ethereum/evm", default-features = false }
-reth-optimism-evm = { path = "crates/optimism/evm", default-features = false }
-reth-execution-errors = { path = "crates/evm/execution-errors", default-features = false }
-reth-execution-types = { path = "crates/evm/execution-types", default-features = false }
-reth-exex = { path = "crates/exex/exex" }
-reth-exex-test-utils = { path = "crates/exex/test-utils" }
-reth-exex-types = { path = "crates/exex/types" }
-reth-fs-util = { path = "crates/fs-util" }
-reth-invalid-block-hooks = { path = "crates/engine/invalid-block-hooks" }
-reth-ipc = { path = "crates/rpc/ipc" }
-reth-libmdbx = { path = "crates/storage/libmdbx-rs" }
-reth-mdbx-sys = { path = "crates/storage/libmdbx-rs/mdbx-sys" }
-reth-metrics = { path = "crates/metrics" }
-reth-net-banlist = { path = "crates/net/banlist" }
-reth-net-nat = { path = "crates/net/nat" }
-reth-network = { path = "crates/net/network" }
-reth-network-api = { path = "crates/net/network-api" }
-reth-network-p2p = { path = "crates/net/p2p" }
-reth-network-peers = { path = "crates/net/peers", default-features = false }
-reth-network-types = { path = "crates/net/network-types" }
-reth-nippy-jar = { path = "crates/storage/nippy-jar" }
-reth-node-api = { path = "crates/node/api" }
-reth-node-builder = { path = "crates/node/builder" }
-reth-node-core = { path = "crates/node/core" }
-reth-node-ethereum = { path = "crates/ethereum/node" }
-reth-node-ethstats = { path = "crates/node/ethstats" }
-reth-node-events = { path = "crates/node/events" }
-reth-node-metrics = { path = "crates/node/metrics" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-consensus-debug-client = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-db-models = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-dns-discovery = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-engine-service = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-engine-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-era = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-era-downloader = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-era-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-exex-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-invalid-block-hooks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-libmdbx = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-mdbx-sys = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-net-banlist = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-network-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-ethstats = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
 reth-optimism-node = { path = "crates/optimism/node" }
-reth-node-types = { path = "crates/node/types" }
-reth-op = { path = "crates/optimism/reth", default-features = false }
-reth-optimism-chainspec = { path = "crates/optimism/chainspec", default-features = false }
+reth-node-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-op = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
 reth-optimism-cli = { path = "crates/optimism/cli", default-features = false }
-reth-optimism-consensus = { path = "crates/optimism/consensus", default-features = false }
+reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
 reth-optimism-exex = { path = "crates/optimism/exex" }
-reth-optimism-forks = { path = "crates/optimism/hardforks", default-features = false }
-reth-optimism-payload-builder = { path = "crates/optimism/payload" }
-reth-optimism-primitives = { path = "crates/optimism/primitives", default-features = false }
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
 reth-optimism-rpc = { path = "crates/optimism/rpc" }
-reth-optimism-storage = { path = "crates/optimism/storage" }
+reth-optimism-storage = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
 reth-optimism-trie = { path = "crates/optimism/trie" }
-reth-optimism-txpool = { path = "crates/optimism/txpool" }
-reth-payload-builder = { path = "crates/payload/builder" }
-reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
-reth-payload-primitives = { path = "crates/payload/primitives" }
-reth-payload-validator = { path = "crates/payload/validator" }
-reth-payload-util = { path = "crates/payload/util" }
-reth-primitives = { path = "crates/primitives", default-features = false }
-reth-primitives-traits = { path = "crates/primitives-traits", default-features = false }
-reth-provider = { path = "crates/storage/provider" }
-reth-prune = { path = "crates/prune/prune" }
-reth-prune-types = { path = "crates/prune/types", default-features = false }
-reth-revm = { path = "crates/revm", default-features = false }
-reth-rpc = { path = "crates/rpc/rpc" }
-reth-rpc-api = { path = "crates/rpc/rpc-api" }
-reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }
-reth-rpc-builder = { path = "crates/rpc/rpc-builder" }
-reth-rpc-e2e-tests = { path = "crates/rpc/rpc-e2e-tests" }
-reth-rpc-engine-api = { path = "crates/rpc/rpc-engine-api" }
-reth-rpc-eth-api = { path = "crates/rpc/rpc-eth-api" }
-reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = false }
-reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
-reth-optimism-flashblocks = { path = "crates/optimism/flashblocks" }
-reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
-reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-stages = { path = "crates/stages/stages" }
-reth-stages-api = { path = "crates/stages/api" }
-reth-stages-types = { path = "crates/stages/types", default-features = false }
-reth-stateless = { path = "crates/stateless", default-features = false }
-reth-static-file = { path = "crates/static-file/static-file" }
-reth-static-file-types = { path = "crates/static-file/types", default-features = false }
-reth-storage-api = { path = "crates/storage/storage-api", default-features = false }
-reth-storage-errors = { path = "crates/storage/errors", default-features = false }
-reth-tasks = { path = "crates/tasks" }
-reth-testing-utils = { path = "testing/testing-utils" }
-reth-tokio-util = { path = "crates/tokio-util" }
-reth-tracing = { path = "crates/tracing", default-features = false }
-reth-tracing-otlp = { path = "crates/tracing-otlp" }
-reth-transaction-pool = { path = "crates/transaction-pool" }
-reth-trie = { path = "crates/trie/trie" }
-reth-trie-common = { path = "crates/trie/common", default-features = false }
-reth-trie-db = { path = "crates/trie/db" }
-reth-trie-parallel = { path = "crates/trie/parallel" }
-reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-trie-sparse-parallel = { path = "crates/trie/sparse-parallel" }
-reth-zstd-compressors = { path = "crates/storage/zstd-compressors", default-features = false }
-reth-ress-protocol = { path = "crates/ress/protocol" }
-reth-ress-provider = { path = "crates/ress/provider" }
+reth-optimism-txpool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-api-testing-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-e2e-tests = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-optimism-flashblocks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-stages-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-tokio-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-trie-sparse-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1", default-features = false }
+reth-ress-protocol = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
+reth-ress-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.1" }
 
 # revm
 revm = { version = "34.0.0", default-features = false }

--- a/crates/optimism/exex/src/lib.rs
+++ b/crates/optimism/exex/src/lib.rs
@@ -174,7 +174,6 @@ where
     /// Ensure proofs storage is initialized
     async fn ensure_initialized(&self) -> eyre::Result<()> {
         // Check if proofs storage is initialized
-        #[cfg_attr(not(feature = "metrics"), expect(unused_variables))]
         let earliest_block_number = match self.storage.get_earliest_block_number().await? {
             Some((n, _)) => n,
             None => {

--- a/crates/optimism/trie/Cargo.toml
+++ b/crates/optimism/trie/Cargo.toml
@@ -42,7 +42,7 @@ bincode.workspace = true
 # misc
 thiserror.workspace = true
 auto_impl.workspace = true
-eyre.workspace = true
+eyre = { workspace = true, optional = true }
 strum.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
@@ -68,6 +68,7 @@ reth-testing-utils.workspace = true
 reth-storage-errors.workspace = true
 secp256k1.workspace = true
 mockall.workspace = true
+eyre.workspace = true
 
 # misc
 serial_test.workspace = true
@@ -85,4 +86,5 @@ metrics = [
     "reth-trie/metrics",
     "dep:reth-metrics",
     "dep:metrics",
+    "dep:eyre",
 ]

--- a/crates/optimism/trie/src/db/store.rs
+++ b/crates/optimism/trie/src/db/store.rs
@@ -478,13 +478,13 @@ impl MdbxProofsStorage {
     ) -> OpProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
-        let storage_trie_len = sorted_trie_updates.storage_tries.len();
+        let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
         let hashed_storage_len = sorted_post_state.storages.len();
 
         let account_trie_keys = self.persist_history_batch(
             tx,
             block_number,
-            sorted_trie_updates.account_nodes.into_iter(),
+            sorted_trie_updates.account_nodes_ref().iter().cloned(),
             append_mode,
         )?;
         let hashed_account_keys = self.persist_history_batch(
@@ -495,14 +495,14 @@ impl MdbxProofsStorage {
         )?;
 
         let mut storage_trie_keys = Vec::<StorageTrieKey>::with_capacity(storage_trie_len);
-        for (hashed_address, nodes) in sorted_trie_updates.storage_tries {
+        for (hashed_address, nodes) in sorted_trie_updates.storage_tries_ref() {
             // Handle wiped - mark all storage trie as deleted at the current block number
             if nodes.is_deleted && append_mode {
                 // Yet to have any update for the current block number - So just using up to
                 // previous block number
-                let mut ro = self.storage_trie_cursor(hashed_address, block_number - 1)?;
+                let mut ro = self.storage_trie_cursor(*hashed_address, block_number - 1)?;
                 let keys =
-                    self.wipe_storage(tx, block_number, hashed_address, || Ok(ro.next()?))?;
+                    self.wipe_storage(tx, block_number, *hashed_address, || Ok(ro.next()?))?;
 
                 storage_trie_keys.extend(keys);
 
@@ -513,7 +513,11 @@ impl MdbxProofsStorage {
             let keys = self.persist_history_batch(
                 tx,
                 block_number,
-                nodes.storage_nodes.into_iter().map(|(path, node)| (hashed_address, path, node)),
+                nodes
+                    .storage_nodes
+                    .clone()
+                    .into_iter()
+                    .map(|(path, node)| (*hashed_address, path, node)),
                 append_mode,
             )?;
             storage_trie_keys.extend(keys);
@@ -1888,8 +1892,8 @@ mod tests {
 
         store.store_trie_updates(block, diff).await.expect("store");
         let got = store.fetch_trie_updates(1).await.expect("fetch");
-        assert!(got.sorted_trie_updates.account_nodes.is_empty());
-        assert!(got.sorted_trie_updates.storage_tries.is_empty());
+        assert!(got.sorted_trie_updates.account_nodes_ref().is_empty());
+        assert!(got.sorted_trie_updates.storage_tries_ref().is_empty());
         assert!(got.sorted_post_state.accounts.is_empty());
         assert!(got.sorted_post_state.storages.is_empty());
     }
@@ -2210,12 +2214,12 @@ mod tests {
 
         // verify trie updates
         assert_eq!(
-            got.sorted_trie_updates.account_nodes,
-            block_state_diff.sorted_trie_updates.account_nodes,
+            got.sorted_trie_updates.account_nodes_ref(),
+            block_state_diff.sorted_trie_updates.account_nodes_ref(),
         );
         assert_eq!(
-            got.sorted_trie_updates.storage_tries,
-            block_state_diff.sorted_trie_updates.storage_tries,
+            got.sorted_trie_updates.storage_tries_ref(),
+            block_state_diff.sorted_trie_updates.storage_tries_ref(),
         );
 
         // verify post state

--- a/deny.toml
+++ b/deny.toml
@@ -93,4 +93,5 @@ allow-git = [
     "https://github.com/alloy-rs/evm",
     "https://github.com/alloy-rs/hardforks",
     "https://github.com/paradigmxyz/jsonrpsee",
+    "https://github.com/paradigmxyz/reth",
 ]


### PR DESCRIPTION
Closes https://github.com/op-rs/op-reth/issues/621

This PR updates the workspace configuration to use reth as a git dependency instead of a local crate, including necessary fixes for the compiler, CI workflows, and test configurations.