### PR TITLE
fix(consensus): Use `no-std` deps in consensus tests

### DIFF
--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -241,7 +241,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     use alloy_consensus::{BlockBody, Eip658Value, Header, Receipt, TxEip7702, TxReceipt};
     use alloy_eips::{eip4895::Withdrawals, eip7685::Requests};

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -199,6 +199,7 @@ fn compare_receipts_root_and_logs_bloom(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::sync::Arc;
     use alloy_consensus::Header;
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::{b256, hex, Bytes, U256};
@@ -207,7 +208,6 @@ mod tests {
     use reth_optimism_chainspec::{OpChainSpec, BASE_SEPOLIA};
     use reth_optimism_forks::{OpHardfork, BASE_SEPOLIA_HARDFORKS};
     use reth_optimism_primitives::OpReceipt;
-    use std::sync::Arc;
 
     const HOLOCENE_TIMESTAMP: u64 = 1700000000;
     const ISTHMUS_TIMESTAMP: u64 = 1750000000;


### PR DESCRIPTION
Use `alloc::sync::Arc` in tests instead of `std::sync::Arc`