### PR TITLE
chore(deps): use upstream reth deps

### DIFF
--- a/.github/assets/check_rv32imac.sh
+++ b/.github/assets/check_rv32imac.sh
@@ -3,39 +3,39 @@ set +e  # Disable immediate exit on error
 
 # Array of crates to check
 crates_to_check=(
-    reth-codecs-derive
-    reth-primitives
-    reth-primitives-traits
-    reth-network-peers
-    reth-trie-common
-    reth-trie-sparse
-    reth-chainspec
-    reth-consensus
-    reth-consensus-common
-    reth-prune-types
-    reth-static-file-types
-    reth-storage-errors
-    reth-execution-errors
-    reth-errors
-    reth-execution-types
-    reth-db-models
-    reth-evm
-    reth-revm
-    reth-storage-api
+    #reth-codecs-derive
+    #reth-primitives
+    #reth-primitives-traits
+    #reth-network-peers
+    #reth-trie-common
+    #reth-trie-sparse
+    #reth-chainspec
+    #reth-consensus
+    #reth-consensus-common
+    #reth-prune-types
+    #reth-static-file-types
+    #reth-storage-errors
+    #reth-execution-errors
+    #reth-errors
+    #reth-execution-types
+    #reth-db-models
+    #reth-evm
+    #reth-revm
+    #reth-storage-api
 
     ## ethereum
-    reth-evm-ethereum
-    reth-ethereum-forks
-    reth-ethereum-primitives
-    reth-ethereum-consensus
-    reth-stateless
+    #reth-evm-ethereum
+    #reth-ethereum-forks
+    #reth-ethereum-primitives
+    #reth-ethereum-consensus
+    #reth-stateless
 
     ## optimism
-    reth-optimism-chainspec
-    reth-optimism-forks
-    reth-optimism-consensus
-    reth-optimism-primitives
-    reth-optimism-evm
+    #reth-optimism-chainspec
+    #reth-optimism-forks
+    #reth-optimism-consensus
+    #reth-optimism-primitives
+    #reth-optimism-evm
 )
 
 # Array to hold the results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - type: ethereum
             args: --workspace --lib --examples --tests --benches --locked
-            features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+            features: "asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
     steps:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -266,7 +266,6 @@ jobs:
           cargo hack check \
             --package reth-optimism-trie \
             --package reth-optimism-exex \
-            --package reth-optimism-node \
             --feature-powerset \
             --depth 2
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -264,9 +264,9 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - run: |
           cargo hack check \
-            --package reth-codecs \
-            --package reth-primitives-traits \
-            --package reth-primitives \
+            --package reth-optimism-trie \
+            --package reth-optimism-exex \
+            --package reth-optimism-node \
             --feature-powerset \
             --depth 2
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - type: ethereum
             args: --workspace --lib --examples --tests --benches --locked
-            features: "asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
+            features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
     steps:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
@@ -77,6 +77,24 @@ jobs:
         run: |
           sudo apt update && sudo apt install gcc-multilib
           .github/assets/check_wasm.sh
+
+  riscv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: riscv32imac-unknown-none-elf
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: dcarbone/install-jq-action@v3
+      - name: Run RISC-V checks
+        run: .github/assets/check_rv32imac.sh
 
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
@@ -225,6 +243,35 @@ jobs:
       - name: Ensure no arbitrary or proptest dependency on default build
         run: cargo tree --package reth -e=features,no-dev | grep -Eq "arbitrary|proptest" && exit 1 || exit 0
 
+  # Checks that selected crates can compile with power set of features
+  features:
+    name: features
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2]
+        total_partitions: [2]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: |
+          cargo hack check \
+            --package reth-codecs \
+            --package reth-primitives-traits \
+            --package reth-primitives \
+            --feature-powerset \
+            --depth 2
+        env:
+          RUSTFLAGS: -D warnings
+
   # Check crates correctly propagate features
   feature-propagation:
     runs-on: ubuntu-latest
@@ -260,6 +307,7 @@ jobs:
       - typos
       - grafana
       - no-test-deps
+      - features
       - feature-propagation
       - deny
     timeout-minutes: 30

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -264,6 +264,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - run: |
           cargo hack check \
+            --all-targets \
             --package reth-optimism-trie \
             --package reth-optimism-exex \
             --feature-powerset \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -51,7 +51,7 @@ jobs:
           cargo nextest run \
             --features "${{ matrix.features }} $EDGE_FEATURES" --locked \
             ${{ matrix.exclude_args }} --workspace \
-            --no-tests=warn \
+            --exclude ef-tests --no-tests=warn \
             -E "!kind(test) and not binary(e2e_testsuite)"
 
   doc:

--- a/crates/optimism/exex/src/lib.rs
+++ b/crates/optimism/exex/src/lib.rs
@@ -174,7 +174,6 @@ where
     /// Ensure proofs storage is initialized
     async fn ensure_initialized(&self) -> eyre::Result<()> {
         // Check if proofs storage is initialized
-        #[cfg_attr(not(feature = "metrics"), expect(unused_variables))]
         let earliest_block_number = match self.storage.get_earliest_block_number().await? {
             Some((n, _)) => n,
             None => {

--- a/crates/optimism/trie/Cargo.toml
+++ b/crates/optimism/trie/Cargo.toml
@@ -68,6 +68,7 @@ reth-testing-utils.workspace = true
 reth-storage-errors.workspace = true
 secp256k1.workspace = true
 mockall.workspace = true
+eyre.workspace = true
 
 # misc
 serial_test.workspace = true

--- a/crates/optimism/trie/Cargo.toml
+++ b/crates/optimism/trie/Cargo.toml
@@ -42,7 +42,7 @@ bincode.workspace = true
 # misc
 thiserror.workspace = true
 auto_impl.workspace = true
-eyre.workspace = true
+eyre = { workspace = true, optional = true }
 strum.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
@@ -85,4 +85,5 @@ metrics = [
     "reth-trie/metrics",
     "dep:reth-metrics",
     "dep:metrics",
+    "dep:eyre",
 ]


### PR DESCRIPTION
- keeps riscv0 workflow but disables for crates unmodified in this fork
- keeps feature powerset checks for new crates