### PR TITLE
chore(trie): Remove redundant generic lifetime for `InitializationJob`

### DIFF
--- a/crates/optimism/cli/src/commands/op_proofs/init.rs
+++ b/crates/optimism/cli/src/commands/op_proofs/init.rs
@@ -80,7 +80,7 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
                 provider_factory.database_provider_ro()?.disable_long_read_transaction_safety();
             let db_tx = db_provider.into_tx();
 
-            InitializationJob::new(storage.clone(), &db_tx).run(best_number, best_hash).await?;
+            InitializationJob::new(storage.clone(), db_tx).run(best_number, best_hash).await?;
         }
 
         info!(

--- a/crates/optimism/cli/src/commands/op_proofs/mod.rs
+++ b/crates/optimism/cli/src/commands/op_proofs/mod.rs
@@ -2,6 +2,7 @@
 
 use clap::{Parser, Subcommand};
 use reth_cli::chainspec::ChainSpecParser;
+use reth_cli_commands::common::CliNodeTypes;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use std::sync::Arc;
@@ -19,12 +20,7 @@ pub struct Command<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> Command<C> {
     /// Execute `op-proofs` command
-    pub async fn execute<
-        N: reth_cli_commands::common::CliNodeTypes<
-            ChainSpec = C::ChainSpec,
-            Primitives = OpPrimitives,
-        >,
-    >(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
         self,
     ) -> eyre::Result<()> {
         match self.command {

--- a/crates/optimism/trie/src/in_memory.rs
+++ b/crates/optimism/trie/src/in_memory.rs
@@ -222,7 +222,7 @@ impl InMemoryTrieCursor {
             };
 
         // Sort by path for consistent ordering
-        collected_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        collected_entries.sort_by_key(|(a, _)| *a);
         self.entries = collected_entries;
         self.is_populated = true;
         Ok(())

--- a/crates/optimism/trie/tests/live.rs
+++ b/crates/optimism/trie/tests/live.rs
@@ -241,7 +241,7 @@ where
     {
         let provider = provider_factory.db_ref();
         let tx = provider.tx()?;
-        let initialization_job = InitializationJob::new(storage.clone(), &tx);
+        let initialization_job = InitializationJob::new(storage.clone(), tx);
         initialization_job.run(last_block_number, last_block_hash).await?;
     }
 


### PR DESCRIPTION
Ref https://github.com/op-rs/op-reth/issues/631

- Changes nested database tx type to owned type as has no need to be ref
- Uses `AsyncFnOnce`(new in Rust 1.85) instead of generic future return type