### PR TITLE
chore(trie): Fix redundant type annotations

### DIFF
--- a/crates/optimism/trie/src/db/store.rs
+++ b/crates/optimism/trie/src/db/store.rs
@@ -1778,8 +1778,7 @@ mod tests {
 
         // incoming block whose parent != existing latest
         let bad_parent = B256::from([0xFF; 32]);
-        let bad_block: BlockWithParent =
-            BlockWithParent::new(bad_parent, NumHash::new(2, B256::ZERO));
+        let bad_block = BlockWithParent::new(bad_parent, NumHash::new(2, B256::ZERO));
         let diff = BlockStateDiff::default();
 
         let res = store.store_trie_updates(bad_block, diff);

--- a/crates/optimism/trie/tests/lib.rs
+++ b/crates/optimism/trie/tests/lib.rs
@@ -991,8 +991,7 @@ fn test_storage_zero_value_deletion<S: OpProofsStore>(
     hashed_storage.storage.insert(storage_key, U256::ZERO);
     block_state_diff_post_state.storages.insert(hashed_address, hashed_storage);
 
-    let block_ref: BlockWithParent =
-        BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
     let block_state_diff = BlockStateDiff {
         sorted_trie_updates: TrieUpdatesSorted::default(),
         sorted_post_state: block_state_diff_post_state.into_sorted(),
@@ -1149,8 +1148,7 @@ fn test_store_trie_updates_with_wiped_storage<S: OpProofsStore>(
     use reth_trie::HashedStorage;
 
     let hashed_address = B256::repeat_byte(0x01);
-    let block_ref: BlockWithParent =
-        BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
+    let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
 
     // First, store some storage values at block 50
     let storage_slots = vec![


### PR DESCRIPTION
Fixes lint `clippy::redundant_type_annotations`