### PR TITLE
chore(ci): Disable job to publish book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -46,14 +46,6 @@ jobs:
           cd docs/vocs/ && bun run build
           echo "Vocs Build Complete"
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: "./docs/vocs/docs/dist"
-
   deploy:
     # Only deploy if a push to main
     if: github.ref_name == 'main' && github.event_name == 'push'


### PR DESCRIPTION
Disables the job to publish books. Will enable this later again as part of issue related to https://github.com/ethereum-optimism/optimism/issues/18929