### PR TITLE
feat(static-file): add production duration metrics

### DIFF
--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -15,20 +15,22 @@ workspace = true
 # reth
 reth-codecs.workspace = true
 reth-db-api.workspace = true
+reth-metrics.workspace = true
+reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
+reth-stages-types.workspace = true
+reth-static-file-types.workspace = true
 reth-storage-errors.workspace = true
 reth-tokio-util.workspace = true
-reth-prune-types.workspace = true
-reth-primitives-traits.workspace = true
-reth-static-file-types.workspace = true
-reth-stages-types.workspace = true
 
 alloy-primitives.workspace = true
 
 # misc
-tracing.workspace = true
-rayon.workspace = true
+metrics.workspace = true
 parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }
+rayon.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 reth-stages = { workspace = true, features = ["test-utils"] }

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod metrics;
 pub mod segments;
 mod static_file_producer;
 

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -1,0 +1,14 @@
+//! Static file producer metrics.
+
+use metrics::Histogram;
+use reth_metrics::Metrics;
+
+/// Static file producer metrics.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "static_file.producer")]
+pub(crate) struct StaticFileProducerMetrics {
+    /// Histogram for the time taken to produce static files for a single segment (in seconds).
+    pub(crate) segment_production_duration: Histogram,
+    /// Histogram for the total time taken to produce all static files (in seconds).
+    pub(crate) total_production_duration: Histogram,
+}

--- a/deny.toml
+++ b/deny.toml
@@ -4,14 +4,10 @@
 [advisories]
 yanked = "warn"
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
-    "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
-    #  https://rustsec.org/advisories/RUSTSEC-2026-0002 lru unused directly: <https://github.com/alloy-rs/alloy/pull/3460>
-    "RUSTSEC-2026-0002",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,10 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0007 bytes integer overflow, will be fixed in separate PR
+    "RUSTSEC-2026-0007",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0009 time DoS vulnerability, will be fixed in separate PR
+    "RUSTSEC-2026-0009",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Adds histogram metrics to track static file production duration at both segment and total levels, resolves existing TODO comments for metric tracking.